### PR TITLE
For recent events, open event details in a virtual document

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "vscode-stripe",
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
     "onCommand:stripe.openDashboardApikeys",
     "onCommand:stripe.openDashboardLogs",
     "onCommand:stripe.openDashboardEvents",
-    "onCommand:stripe.openDashboardEventDetails",
     "onCommand:stripe.openDashboardWebhooks",
+    "onCommand:stripe.openEventDetails",
     "onCommand:stripe.openTriggerEvent",
     "onCommand:stripe.openReportIssue",
     "onCommand:stripe.openDocs",
@@ -122,8 +122,8 @@
       },
       {
         "category": "Stripe",
-        "command": "stripe.openDashboardEventDetails",
-        "title": "Open Dashboard with a specific event"
+        "command": "stripe.openEventDetails",
+        "title": "Open read-only document with a specific event"
       },
       {
         "category": "Stripe",
@@ -185,7 +185,7 @@
       ],
       "commandPalette": [
         {
-          "command": "stripe.openDashboardEventDetails",
+          "command": "stripe.openEventDetails",
           "when": "false"
         }
       ]

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -88,11 +88,19 @@ export function openDashboardWebhooks() {
   );
 }
 
-export function openDashboardEventDetails(data: any) {
-  telemetry.sendEvent("openDashboardEventDetails");
-  let id = data.id;
-  let url = `https://dashboard.stripe.com/test/events/${id}`;
-  vscode.env.openExternal(vscode.Uri.parse(url));
+export async function openEventDetails(data: any) {
+  telemetry.sendEvent("openEventDetails");
+  const {id, type} = data;
+  const filename = `${type} (${id})`;
+  const uri = vscode.Uri.parse(`stripeEvent:${filename}`);
+  vscode.window.withProgress({
+      location: vscode.ProgressLocation.Window,
+      title: "Fetching Stripe event details",
+  }, async () => {
+    const doc = await vscode.workspace.openTextDocument(uri);
+    vscode.languages.setTextDocumentLanguage(doc, "json");
+    vscode.window.showTextDocument(doc, {preview: false});
+  });
 }
 
 export function refreshEventsList(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,4 @@
-import { commands, debug, window, ExtensionContext } from "vscode";
+import { commands, debug, window, ExtensionContext, workspace } from "vscode";
 
 import { ServerOptions, TransportKind } from "vscode-languageclient";
 
@@ -25,7 +25,7 @@ import {
   openDashboardApikeys,
   openDashboardWebhooks,
   openDashboardLogs,
-  openDashboardEventDetails,
+  openEventDetails,
   refreshEventsList,
   startLogin,
   openTriggerEvent,
@@ -34,6 +34,7 @@ import {
   openReportIssue,
   openDocs,
 } from "./commands";
+import { StripeEventTextDocumentContentProvider } from "./stripeEventTextDocumentContentProvider";
 
 export async function activate(this: any, context: ExtensionContext) {
   // Stripe CLi client
@@ -76,6 +77,12 @@ export async function activate(this: any, context: ExtensionContext) {
 
   // Debug provider
   debug.registerDebugConfigurationProvider("stripe", new StripeDebugProvider());
+
+  // Virtual document content provider for displaying event data
+  workspace.registerTextDocumentContentProvider(
+    "stripeEvent",
+    new StripeEventTextDocumentContentProvider(stripeClient)
+  );
 
   // Stripe Linter
   let stripeLinter = new StripeLinter();
@@ -132,8 +139,8 @@ export async function activate(this: any, context: ExtensionContext) {
 
   subscriptions.push(
     commands.registerCommand(
-      "stripe.openDashboardEventDetails",
-      openDashboardEventDetails
+      "stripe.openEventDetails",
+      openEventDetails
     )
   );
 

--- a/src/stripeClient.ts
+++ b/src/stripeClient.ts
@@ -147,6 +147,11 @@ export class StripeClient {
     let events = this.execute("events list");
     return events;
   }
+
+  getResourceById(id: string) {
+    const resource = this.execute(`get ${id}`);
+    return resource;
+  }
 }
 
 function getInstallPath(paths: string[]): string {

--- a/src/stripeEventTextDocumentContentProvider.ts
+++ b/src/stripeEventTextDocumentContentProvider.ts
@@ -1,0 +1,40 @@
+import * as vscode from "vscode";
+import { StripeClient } from "./stripeClient";
+
+export class StripeEventTextDocumentContentProvider implements vscode.TextDocumentContentProvider {
+  private static EVENT_ID_REGEX = /evt_[\w]+/;
+
+  private stripeClient: StripeClient;
+
+  constructor(stripeClient: StripeClient) {
+    this.stripeClient = stripeClient;
+  }
+
+  async provideTextDocumentContent(uri: vscode.Uri): Promise<string | null> {
+    const eventId = this.getResourceIdFromUri(uri);
+    if (!eventId) {
+      return null;
+    }
+
+    const eventResource = await this.stripeClient.getResourceById(eventId);
+
+    // respect workspace tab settings, or default to 2 spaces
+    const editorConfig = vscode.workspace.getConfiguration('editor');
+    const insertSpaces = editorConfig.get('insertSpaces', true);
+    const tabSize = editorConfig.get('tabSize', 2);
+    const space = insertSpaces ? tabSize : '\t';
+
+    const eventDataJsonString = JSON.stringify(eventResource, undefined, space);
+    return eventDataJsonString;
+  }
+
+  private getResourceIdFromUri(uri: vscode.Uri): string | null {
+    const {path} = uri;
+    const match = path.match(StripeEventTextDocumentContentProvider.EVENT_ID_REGEX);
+    if (!match || match.length < 1) {
+      return null;
+    }
+    const [id] = match;
+    return id;
+  }
+}

--- a/src/stripeEventsView.ts
+++ b/src/stripeEventsView.ts
@@ -24,7 +24,7 @@ export class StripeEventsDataProvider extends StripeTreeViewDataProvider {
           let title = event.type;
           let eventItem = new StripeTreeItem(
             title,
-            "openDashboardEventDetails"
+            "openEventDetails"
           );
           eventItem.metadata = {
             type: event.type,


### PR DESCRIPTION
Resolves #40.

For recent events, open event details in a virtual document rather than linking externally to its dashboard page.
- These virtual documents are opened in non-preview mode so that each one stays open in its own tab.
- The documents are opened with language set to JSON for syntax highlighting.
- The data is fetched via the Stripe CLI; as such, the data may be slow to load, so there is a loading indicator in the status bar for long-running fetches.
- The name of the tab is in the format `<event type> (<event ID>)` so users can see the human-readable event type, but also distinguish tabs by the event ID.

Tested manually.

<img width="1136" alt="Screen Shot 2020-11-02 at 3 03 50 PM" src="https://user-images.githubusercontent.com/71457708/97928855-b2bdb900-1d1c-11eb-8281-d1587edb6a85.png">



