### PR TITLE
For Stripe API Reference URLs, add lang parameter

### DIFF
--- a/src/stripeLanguageServer/server.ts
+++ b/src/stripeLanguageServer/server.ts
@@ -11,6 +11,7 @@ import {
 import { TextDocument } from "vscode-languageserver-textdocument";
 
 import { stripeMethodList } from "./patterns";
+import { getStripeApiReferenceUrl } from "./utils";
 
 let connection = createConnection(ProposedFeatures.all);
 
@@ -89,7 +90,7 @@ function findHoverMatches(params: HoverParams): string[] {
         hoverPosition <= methodPositionEnd
       ) {
         hoverMatches.push(
-          `See ${methodMatch} in the [Stripe API Reference](https://stripe.com/docs/api${stripeMethod.url})`
+          `See ${methodMatch} in the [Stripe API Reference](${getStripeApiReferenceUrl(stripeMethod, document.languageId)})`
         );
         connection.telemetry.logEvent({name: 'ls.apihover', data: methodMatch});
       }

--- a/src/stripeLanguageServer/utils.ts
+++ b/src/stripeLanguageServer/utils.ts
@@ -1,0 +1,32 @@
+import { Pattern } from './patterns';
+import querystring from 'querystring';
+
+// Convert an LSP language identifier to a URL param `lang` for the Stripe API Reference pages
+// See https://microsoft.github.io/language-server-protocol/specification#textDocumentItem
+function getLangUrlParamFromLanguageId(languageId: string): string | null {
+  switch (languageId) {
+    case 'csharp':
+      return 'dotnet';
+    case 'javascript':
+    case 'typescript':
+      return 'node';
+    case 'go':
+    case 'java':
+    case 'php':
+    case 'python':
+    case 'ruby':
+      return languageId;
+    default:
+      return null;
+  }
+}
+
+export function getStripeApiReferenceUrl(stripeMethod: Pattern, languageId: string) {
+  const lang = getLangUrlParamFromLanguageId(languageId);
+  const urlParams = {
+    ...(lang ? {lang} : {})
+  };
+  const paramsString = querystring.stringify(urlParams);
+  const prefixedParamString = paramsString ? `?${paramsString}` : '';
+  return `https://stripe.com/docs/api${stripeMethod.url}${prefixedParamString}`;
+}

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -2,11 +2,14 @@ import * as assert from 'assert';
 import * as vscode from 'vscode';
 
 suite('Extension Test Suite', () => {
-  test("Should start extension vscode-stripe", () => {
+  test("Should start extension vscode-stripe", async () => {
     const started = vscode.extensions.getExtension(
       "stripe.vscode-stripe",
     );
     assert.notStrictEqual(started, undefined);
+    if (started) {
+      await started.activate();
+    }
     assert.strictEqual(started && started.isActive, true);
   });
 });

--- a/src/test/suite/stripeLanguageServer.test.ts
+++ b/src/test/suite/stripeLanguageServer.test.ts
@@ -1,0 +1,34 @@
+import * as assert from 'assert';
+import * as utils from '../../stripeLanguageServer/utils';
+import { stripeMethodList } from '../../stripeLanguageServer/patterns';
+
+suite('Stripe language server', () => {
+  suite('API Reference URL', () => {
+    test('Should get Stripe API Reference URL with the right language preset', () => {
+      const stripeMethod = stripeMethodList[0];
+      [
+        ['csharp', 'dotnet'],
+        ['javascript', 'node'],
+        ['typescript', 'node'],
+        ['go', 'go'],
+        ['java', 'java'],
+        ['php', 'php'],
+        ['python', 'python'],
+        ['ruby', 'ruby'],
+      ].forEach(([languageId, langUrlParam]) => {
+        assert.strictEqual(
+          utils.getStripeApiReferenceUrl(stripeMethod, languageId),
+          `https://stripe.com/docs/api/balance/balance_retrieve?lang=${langUrlParam}`
+        );
+      });
+    });
+
+    test('Should get Stripe API Reference URL without a language preset if language is not supported', () => {
+      const stripeMethod = stripeMethodList[0];
+      assert.strictEqual(
+        utils.getStripeApiReferenceUrl(stripeMethod, 'unsupportedLanguage'),
+        'https://stripe.com/docs/api/balance/balance_retrieve'
+      );
+    });
+  });
+});


### PR DESCRIPTION
# Summary
cc @stripe/developer-products 

In a user's source code, when the user hovers over a Stripe method, we show a link to the method's API Reference page with the URL's `lang` param set to whatever their document's language is. If Stripe doesn't support the language, do not add the `lang` param.

<img width="550" alt="Screen Shot 2020-11-09 at 10 23 38 AM" src="https://user-images.githubusercontent.com/71457708/98581525-763b1180-2276-11eb-9185-54cfe0f2f27d.png">

# Motivation
Resolves #49.

# Testing
Added test for the function that generates the URL; manually tested the hover functionality.