### PR TITLE
Support forwarding Connect events when listening to webhooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,18 +57,19 @@ The Stripe debug configuration can be combined with other configurations, so you
       "request": "launch",
       "command": "listen",
       "forwardTo": "http://localhost:3000",
+      "forwardConnectTo": "http://localhost:3000",
     }
   ]
 }
 ```
 
-For the `stripe` debug configuration you can also specify `forwardTo` which is the URL of your local server that should receive your webhooks traffic. You can also specify `events` which is an optional array that allows you to filter which events you want to have forwarded.
+For the `stripe` debug configuration you can also specify `forwardTo` and `forwardConnectTo`, which are the URLs of your local servers that should receive your normal and Connect webhooks events respectively. You can also specify `events` which is an optional array that allows you to filter which events you want to have forwarded.
 
 #### Compound configurations
 
 You can combine the `stripe` debug configuration with `compounds` configurations to have one configuration that launches your API and stripe at the same time:
 
-```
+```json
 {
   "version": "0.2.0",
   "configurations": [
@@ -78,6 +79,7 @@ You can combine the `stripe` debug configuration with `compounds` configurations
       "request": "launch",
       "command": "listen",
       "forwardTo": "http://localhost:3000",
+      "forwardConnectTo": "http://localhost:3000",
       "events": ["payment_intent.succeeded", "payment_intent.canceled"] // Optional array if only specific events are wanted
     },
     {

--- a/package.json
+++ b/package.json
@@ -220,6 +220,11 @@
                 "description": "The URL to forward webhook events to",
                 "default": "http://localhost:3000"
               },
+              "forwardConnectTo": {
+                "type": "string",
+                "description": "The URL to forward Connect webhook events to (default: same as normal events)",
+                "default": "http://localhost:3000"
+              },
               "command": {
                 "type": "string",
                 "description": "Command to execute",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -13,7 +13,7 @@ const terminal = new StripeTerminal();
 export async function openWebhooksListen(options: any) {
   telemetry.sendEvent("openWebhooksListen");
 
-  const shouldPromptForURL = !options.forwardTo &&
+  const shouldPromptForURL = !options.forwardTo && !options.forwardConnectTo &&
     await showQuickPickWithValues(
       "Do you want to forward webhook events to your local server?",
       ["Yes", "No"]
@@ -28,8 +28,21 @@ export async function openWebhooksListen(options: any) {
       )
     : options.forwardTo;
 
+  const forwardConnectTo = shouldPromptForURL
+    ? await vscode.window.showInputBox(
+        {
+          prompt: "Enter local server URL to forward Connect webhook events to (default: same as normal events)",
+          value: forwardTo || "http://localhost:3000",
+        }
+      )
+    : options.forwardConnectTo;
+
   const forwardToFlag = forwardTo
     ? ["--forward-to", forwardTo]
+    : [];
+
+  const forwardConnectToFlag = forwardConnectTo
+    ? ["--forward-connect-to", forwardConnectTo]
     : [];
 
   const eventsFlag = Array.isArray(options.events) && options.events.length > 0
@@ -39,6 +52,7 @@ export async function openWebhooksListen(options: any) {
   const command = [
     "stripe listen",
     ...forwardToFlag,
+    ...forwardConnectToFlag,
     ...eventsFlag
   ].join(" ");
 

--- a/src/stripeDebugProvider.ts
+++ b/src/stripeDebugProvider.ts
@@ -13,21 +13,6 @@ export class StripeDebugProvider implements vscode.DebugConfigurationProvider {
     });
   }
 
-  public async provideDebugConfigurations(
-    folder: vscode.WorkspaceFolder | undefined,
-    token?: vscode.CancellationToken
-  ): Promise<vscode.DebugConfiguration[]> {
-    return Promise.resolve([
-      {
-        name: "Stripe: Webhooks listen",
-        type: "stripe",
-        request: "launch",
-        command: "listen",
-        forwardTo: "http://localhost:3000",
-      },
-    ]);
-  }
-
   public async resolveDebugConfiguration(
     folder: vscode.WorkspaceFolder | undefined,
     config: vscode.DebugConfiguration,
@@ -44,6 +29,7 @@ export class StripeDebugProvider implements vscode.DebugConfigurationProvider {
 
         vscode.commands.executeCommand(`stripe.openWebhooksListen`, {
           forwardTo: config.forwardTo,
+          forwardConnectTo: config.forwardConnectTo,
           events: config.events,
         });
       }


### PR DESCRIPTION
# Summary
cc @stripe/developer-products 

- Support `forwardConnectTo` for webhooks listening in the user's debugging configuration (equivalent to `--forward-connect-to` in the Stripe CLI). This option can be
  - specified in a user's `.vscode/launch.json`
  - entered via a prompt if the user doesn't specify `forwardTo` or `forwardConnectTo` in their `.vscode/launch.json`
  - entered via a prompt if the user user clicks "Start webhooks listening" in the activity bar
- Update the README to show the usage of this option.
- Remove an unused function in the debug provider.

# Motivation

Resolves #50

# Testing

Manually tested:
- put `forwardConnectTo` in my debugging configuration and verify that it gets passed to `stripe listen` as `--foward-connect-to`
- leave out both `forwardTo` and `forwardConnectTo` in my debugging configuration and verify that I get prompted for them
- click "Start webhooks listening" in the activity bar, verify that I get prompted for a URL for both `forwardTo` and `forwardConnectTo`