### PR TITLE
Validate input to the terminal

### DIFF
--- a/src/stripeTerminal.ts
+++ b/src/stripeTerminal.ts
@@ -2,6 +2,8 @@ import * as vscode from "vscode";
 import psList from "ps-list";
 import { getOSType, OSType, filterAsync, findAsync } from "./utils";
 
+type SupportedStripeCommand = "listen" | "logs" | "login" | "trigger";
+
 export class StripeTerminal {
   private static KNOWN_LONG_RUNNING_COMMANDS = [
     "stripe listen",
@@ -18,9 +20,13 @@ export class StripeTerminal {
     });
   }
 
-  public async execute(command: string): Promise<void> {
-    const terminal = await this.terminalForCommand(command);
-    terminal.sendText(command);
+  public async execute(
+    command: SupportedStripeCommand,
+    args: Array<string> = [],
+  ): Promise<void> {
+    const commandString = ["stripe", command, ...args].join(" ");
+    const terminal = await this.terminalForCommand(commandString);
+    terminal.sendText(commandString);
     terminal.show();
     const otherTerminals = this.terminals.filter((t) => t !== terminal);
     this.freeUnusedTerminals(otherTerminals);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -33,7 +33,7 @@ export function getOSType(): OSType {
 export async function showQuickPickWithValues(
   placeholder: string,
   items: string[]
-) {
+): Promise<string> {
   return new Promise((resolve, reject) => {
     const input = vscode.window.createQuickPick();
     input.placeholder = placeholder;


### PR DESCRIPTION
# Summary
cc @stripe/developer-products 

- Change the signature of `StripeTerminal.execute()` from `(command: string) => Promise<void>` to `(command: SupportedStripeCommand, args: Array<string>) => Promise(void)`, where `SupportedStripeCommand` is an allowlist of Stripe CLI commands currently supported by the extension.
- Validate user input that will be sent to the terminal. Show an error message in VS Code if there is bad input.

# Motivation
The input validation ensures a user's input to the terminal is formatted correctly, and the allowlist ensures only a particular set of Stripe commands can be run. Both reduce the chance of unintended input being sent to the terminal.

# Testing
- Manually tested:
  - Run the commands and verify that the change in the `StripeTerminal.execute()` signature is a no-op.
  - Pass a poorly formatted URL and events to the webhooks listening command, verify that an error message pops up in VS Code.
