### PR TITLE
User can specify a Stripe CLI project name in their workspace settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,10 @@
           "description": "Install path for the Stripe CLI executable (include the complete filepath to the executable)",
           "type": "string"
         },
+        "stripe.projectName": {
+          "type": "string",
+          "description": "the project name to read from for config (default \"default\")"
+        },
         "stripe.telemetry.enabled": {
           "type": "boolean",
           "default": true,

--- a/src/stripeClient.ts
+++ b/src/stripeClient.ts
@@ -16,6 +16,7 @@ export class StripeClient {
   constructor() {
     this.isInstalled = false;
     this.cliPath = "";
+    vscode.workspace.onDidChangeConfiguration(this.handleDidChangeConfiguration, this);
   }
 
   private async execute(command: string) {
@@ -69,7 +70,7 @@ export class StripeClient {
   private async promptLogin() {
     let actionText = "Run `stripe login` in the terminal to login";
     let returnValue = await window.showErrorMessage(
-      `You need to login with the Stripe CLI before you can continue`,
+      `You need to login with the Stripe CLI for this project before you can continue`,
       {},
       ...[actionText]
     );
@@ -152,6 +153,16 @@ export class StripeClient {
   getResourceById(id: string) {
     const resource = this.execute(`get ${id}`);
     return resource;
+  }
+
+  private async handleDidChangeConfiguration(e: vscode.ConfigurationChangeEvent) {
+    const shouldHandleConfigurationChange = e.affectsConfiguration("stripe");
+    if (shouldHandleConfigurationChange) {
+      const isAuthenticated = await this.isAuthenticated();
+      if (!isAuthenticated) {
+        await this.promptLogin();
+      }
+    }
   }
 }
 

--- a/src/stripeTerminal.ts
+++ b/src/stripeTerminal.ts
@@ -24,7 +24,15 @@ export class StripeTerminal {
     command: SupportedStripeCommand,
     args: Array<string> = [],
   ): Promise<void> {
-    const commandString = ["stripe", command, ...args].join(" ");
+    const globalCLIFLags = this.getGlobalCLIFlags();
+
+    const commandString = [
+      "stripe",
+      command,
+      ...args,
+      ...globalCLIFLags
+    ].join(" ");
+
     const terminal = await this.terminalForCommand(commandString);
     terminal.sendText(commandString);
     terminal.show();
@@ -121,5 +129,18 @@ export class StripeTerminal {
       t.dispose();
     });
     this.terminals = this.terminals.filter((t) => !unusedTerminals.includes(t));
+  }
+
+  // The Stripe CLI supports a number of flags for every command. See https://stripe.com/docs/cli/flags
+  private getGlobalCLIFlags(): Array<string> {
+    const stripeConfig = vscode.workspace.getConfiguration("stripe");
+
+    const projectName = stripeConfig.get("projectName", null);
+
+    const projectNameFlag = projectName ? ["--project-name", projectName] : [];
+
+    return [
+      ...projectNameFlag,
+    ];
   }
 }


### PR DESCRIPTION
# Summary
cc @stripe/developer-products 

Add a workspace setting `stripe.projectName` that allows a user to specify a project name to use for all Stripe CLI commands, equivalent to the CLI's `--project-name` flag. The user is prompted to re-login to the CLI if they change their project name and don't already have a config for that project.

<img width="1136" alt="Screen Shot 2020-12-02 at 12 25 47 PM" src="https://user-images.githubusercontent.com/71457708/100927279-86bb6200-3499-11eb-8f4b-5721a62756f1.png">

# Motivation
Resolves #22 

# Testing
Tested manually:
- Add the project name to my `vscode.settings.json`, verify that I get prompted to re-login.
- Click on all the actions, verify that the `--project-name` flag is passed to the Stripe CLI.
