### PR TITLE
update stripe linter to allow for longer API Keys

### DIFF
--- a/src/stripeLinter.ts
+++ b/src/stripeLinter.ts
@@ -26,7 +26,7 @@ const gitAPI = isUsingGitExtension ? gitExtensionExports.getAPI(1) : null;
 
 const ignoredFileList = [".env"];
 const stripeKeysRegex = new RegExp(
-  "(sk_test|sk_live|pk_test|pk_live|rk_test|rk_live)_[a-zA-Z0-9]{10,64}",
+  "(sk_test|sk_live|pk_test|pk_live|rk_test|rk_live)_[a-zA-Z0-9]+",
   "g"
 );
 const diagnosticMessageNoGit =


### PR DESCRIPTION
cc @stripe/developer-products

# Summary

👋  just a smöl eleventh hour fix for the beta.

Our API Keys are becoming longer these days so I wanted to ensure our linter can recognise newer ones. I increased the length of characters in the regular expression.

# Motivation

Improved linter = improved developer experience
