### PR TITLE
Treat the user's manually created Stripe terminal as if the extension created it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,51 @@
 			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
 			"integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ=="
 		},
+		"@sinonjs/commons": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
+			"integrity": "sha512-892K+kWUUi3cl+LlqEWIDrhvLgdL79tECi8JZUyq6IviKy/DNhuzCRlbHUjxK89f4ypPMMaFnFuR9Ie6DoIMsw==",
+			"dev": true,
+			"requires": {
+				"type-detect": "4.0.8"
+			}
+		},
+		"@sinonjs/fake-timers": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+			"integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+			"dev": true,
+			"requires": {
+				"@sinonjs/commons": "^1.7.0"
+			}
+		},
+		"@sinonjs/formatio": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-5.0.1.tgz",
+			"integrity": "sha512-KaiQ5pBf1MpS09MuA0kp6KBQt2JUOQycqVG1NZXvzeaXe5LGFqAKueIS0bw4w0P9r7KuBSVdUk5QjXsUdu2CxQ==",
+			"dev": true,
+			"requires": {
+				"@sinonjs/commons": "^1",
+				"@sinonjs/samsam": "^5.0.2"
+			}
+		},
+		"@sinonjs/samsam": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.3.0.tgz",
+			"integrity": "sha512-hXpcfx3aq+ETVBwPlRFICld5EnrkexXuXDwqUNhDdr5L8VjvMeSRwyOa0qL7XFmR+jVWR4rUZtnxlG7RX72sBg==",
+			"dev": true,
+			"requires": {
+				"@sinonjs/commons": "^1.6.0",
+				"lodash.get": "^4.4.2",
+				"type-detect": "^4.0.8"
+			}
+		},
+		"@sinonjs/text-encoding": {
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+			"integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+			"dev": true
+		},
 		"@szmarczak/http-timer": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
@@ -75,6 +120,21 @@
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
 			"integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
+			"dev": true
+		},
+		"@types/sinon": {
+			"version": "9.0.9",
+			"resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-9.0.9.tgz",
+			"integrity": "sha512-z/y8maYOQyYLyqaOB+dYQ6i0pxKLOsfwCmHmn4T7jS/SDHicIslr37oE3Dg8SCqKrKeBy6Lemu7do2yy+unLrw==",
+			"dev": true,
+			"requires": {
+				"@types/sinonjs__fake-timers": "*"
+			}
+		},
+		"@types/sinonjs__fake-timers": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.2.tgz",
+			"integrity": "sha512-dIPoZ3g5gcx9zZEszaxLSVTvMReD3xxyyDnQUjA6IYDG9Ba2AV0otMPs+77sG9ojB4Qr2N2Vk5RnKeuA0X/0bg==",
 			"dev": true
 		},
 		"@types/unist": {
@@ -1486,6 +1546,12 @@
 			"integrity": "sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==",
 			"dev": true
 		},
+		"isarray": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+			"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+			"dev": true
+		},
 		"isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -1554,6 +1620,12 @@
 				"verror": "1.10.0"
 			}
 		},
+		"just-extend": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.1.tgz",
+			"integrity": "sha512-aWgeGFW67BP3e5181Ep1Fv2v8z//iBJfrvyTnq8wG86vEESwmonn1zPBJ0VfmT9CJq2FIT0VsETtrNFm2a+SHA==",
+			"dev": true
+		},
 		"keyv": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
@@ -1590,6 +1662,12 @@
 			"version": "4.17.15",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
 			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+			"dev": true
+		},
+		"lodash.get": {
+			"version": "4.4.2",
+			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+			"integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
 			"dev": true
 		},
 		"log-symbols": {
@@ -2063,6 +2141,19 @@
 			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
 			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
 		},
+		"nise": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/nise/-/nise-4.0.4.tgz",
+			"integrity": "sha512-bTTRUNlemx6deJa+ZyoCUTRvH3liK5+N6VQZ4NIw90AgDXY6iPnsqplNFf6STcj+ePk0H/xqxnP75Lr0J0Fq3A==",
+			"dev": true,
+			"requires": {
+				"@sinonjs/commons": "^1.7.0",
+				"@sinonjs/fake-timers": "^6.0.0",
+				"@sinonjs/text-encoding": "^0.7.1",
+				"just-extend": "^4.0.2",
+				"path-to-regexp": "^1.7.0"
+			}
+		},
 		"njct": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/njct/-/njct-8.0.0.tgz",
@@ -2352,6 +2443,15 @@
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
 			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
 			"dev": true
+		},
+		"path-to-regexp": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+			"integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+			"dev": true,
+			"requires": {
+				"isarray": "0.0.1"
+			}
 		},
 		"performance-now": {
 			"version": "2.1.0",
@@ -2791,6 +2891,44 @@
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
 			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
 		},
+		"sinon": {
+			"version": "9.2.1",
+			"resolved": "https://registry.npmjs.org/sinon/-/sinon-9.2.1.tgz",
+			"integrity": "sha512-naPfsamB5KEE1aiioaoqJ6MEhdUs/2vtI5w1hPAXX/UwvoPjXcwh1m5HiKx0HGgKR8lQSoFIgY5jM6KK8VrS9w==",
+			"dev": true,
+			"requires": {
+				"@sinonjs/commons": "^1.8.1",
+				"@sinonjs/fake-timers": "^6.0.1",
+				"@sinonjs/formatio": "^5.0.1",
+				"@sinonjs/samsam": "^5.2.0",
+				"diff": "^4.0.2",
+				"nise": "^4.0.4",
+				"supports-color": "^7.1.0"
+			},
+			"dependencies": {
+				"diff": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+					"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
 		"spdx-correct": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
@@ -3019,6 +3157,12 @@
 			"version": "0.14.5",
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
 			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+		},
+		"type-detect": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+			"dev": true
 		},
 		"type-fest": {
 			"version": "0.11.0",

--- a/package.json
+++ b/package.json
@@ -272,11 +272,13 @@
     "@types/glob": "^7.1.3",
     "@types/mocha": "^8.0.3",
     "@types/node": "^10.14.17",
+    "@types/sinon": "^9.0.9",
     "@types/vscode": "^1.44.0",
     "glob": "^7.1.6",
     "mocha": "^8.2.1",
     "remark": "^12.0.0",
     "remark-package-dependencies": "^1.1.0",
+    "sinon": "^9.2.1",
     "tslint": "^5.16.0",
     "typescript": "^3.5.1",
     "vscode-test": "^1.4.1"

--- a/src/test/suite/stripeTerminal.test.ts
+++ b/src/test/suite/stripeTerminal.test.ts
@@ -1,0 +1,83 @@
+import * as vscode from "vscode";
+import * as assert from "assert";
+import * as sinon from "sinon";
+import { StripeTerminal } from "../../stripeTerminal";
+
+suite("stripeTerminal", function() {
+  this.timeout(20000);
+
+  let sandbox: sinon.SinonSandbox;
+
+  const terminalStub = <vscode.Terminal>{
+    name: "Stubbed Terminal",
+    processId: Promise.resolve(undefined),
+    creationOptions: {},
+    exitStatus: undefined,
+    sendText: (text: string, addNewLine?: boolean) => {},
+    show: (preserveFocus?: boolean) => {},
+    hide: () => {},
+    dispose: () => {},
+  };
+
+  setup(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  teardown(() => {
+    sandbox.restore();
+  });
+
+  test("sends command to a new terminal if no terminals exist", async () => {
+    const sendTextStub = sandbox.stub(terminalStub, "sendText");
+    const createTerminalStub = sandbox.stub(vscode.window, "createTerminal").returns(terminalStub);
+
+    const stripeTerminal = new StripeTerminal();
+    await stripeTerminal.execute("listen", ["--foward-to", "localhost"]);
+
+    assert.strictEqual(createTerminalStub.callCount, 1);
+    assert.strictEqual(sendTextStub.getCalls()[0].args[0], 'stripe listen --foward-to localhost');
+  });
+
+  test("sends long-running command to a user-created Stripe terminal", async () => {
+    // The user created a terminal and ran `stripe listen` manually.
+    const sendTextStub = sandbox.stub(terminalStub, "sendText");
+    sandbox.stub(vscode.window, "terminals").value([terminalStub]);
+    sandbox.stub(StripeTerminal.prototype, <any>"getRunningCommand").returns("stripe listen");
+
+    const createTerminalStub = sandbox.stub(vscode.window, "createTerminal");
+
+    // The user invokes "Start webhooks listening" from the extension.
+    const stripeTerminal = new StripeTerminal();
+    await stripeTerminal.execute("listen");
+
+    assert.strictEqual(createTerminalStub.callCount, 0);
+    assert.strictEqual(sendTextStub.getCalls()[0].args[0], "stripe listen");
+  });
+
+  test("splits off of a user-created Stripe terminal", async () => {
+    // The user created a terminal and ran `stripe listen` manually.
+    const usersSendTextStub = sandbox.stub(terminalStub, "sendText");
+    sandbox.stub(vscode.window, "terminals").value([terminalStub]);
+    sandbox.stub(StripeTerminal.prototype, <any>"getRunningCommand").returns("stripe listen");
+
+    const newTerminalStub = {
+      ...terminalStub,
+      sendText: (text: string, addNewLine?: boolean) => {},
+    };
+    const createNewSplitTerminalStub = sandbox
+      .stub(StripeTerminal.prototype, <any>"createNewSplitTerminal")
+      .returns(newTerminalStub);
+    const newSendTextStub = sandbox.stub(newTerminalStub, "sendText");
+
+    const createTerminalStub = sandbox.stub(vscode.window, "createTerminal");
+
+    // The user invokes "Start API logs streaming" from the extension.
+    const stripeTerminal = new StripeTerminal();
+    await stripeTerminal.execute("logs", ["tail"]);
+
+    assert.strictEqual(createTerminalStub.callCount, 0);
+    assert.strictEqual(usersSendTextStub.callCount, 0);
+    assert.strictEqual(createNewSplitTerminalStub.callCount, 1);
+    assert.strictEqual(newSendTextStub.getCalls()[0].args[0], "stripe logs tail");
+  });
+});


### PR DESCRIPTION
# Summary
cc @stripe/developer-products 

Before, if the user ran `stripe listen` manually in their integrated terminal, our extension would ignore that terminal. This would cause unexpected behavior where if the user used our extension to run another command (e.g. "Start API logs streaming"), a new terminal would spawn rather than split off of or reuse the user's terminal.

This change looks for user-created terminals running Stripe commands and keeps track of them so that we can split off of or reuse them, a better experience for the user.

To add tests for this, we add `sinon` as a dependency, which resolves #86.

# Motivation
Fixes #55
Resolves #86

# Testing
Added unit tests that mock vscode behavior and assert on vscode methods being called.
Manually verified the behavior on macOS and a Windows VM.