### PR TITLE
Lint API keys on file open and change

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+src/test/workspace/

--- a/src/stripeLinter.ts
+++ b/src/stripeLinter.ts
@@ -3,9 +3,9 @@ import {
   DiagnosticCollection,
   DiagnosticSeverity,
   Range,
+  TextDocument,
   extensions,
   languages,
-  window,
   workspace,
 } from 'vscode';
 
@@ -106,16 +106,14 @@ const shouldSearchFile = (currentFilename: string): boolean => {
 
 export class StripeLinter {
   activate() {
-    this.lookForHardCodedAPIKeys();
-    workspace.onDidSaveTextDocument(this.lookForHardCodedAPIKeys);
+    workspace.textDocuments.forEach(this.lookForHardCodedAPIKeys);
+    workspace.onDidOpenTextDocument(this.lookForHardCodedAPIKeys);
+    workspace.onDidChangeTextDocument(({document}) => {
+      this.lookForHardCodedAPIKeys(document);
+    });
   }
 
-  lookForHardCodedAPIKeys = (): void => {
-    const editor = window.activeTextEditor;
-    if (!editor) { return; }
-
-    const {document} = editor;
-
+  lookForHardCodedAPIKeys = (document: TextDocument): void => {
     const currentFilename = document.uri.path;
     if (!shouldSearchFile(currentFilename)) { return; }
 

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -1,0 +1,5 @@
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}

--- a/src/test/suite/stripeLinter.test.ts
+++ b/src/test/suite/stripeLinter.test.ts
@@ -1,0 +1,48 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import {StripeLinter} from '../../stripeLinter';
+import {sleep} from '../helpers';
+
+suite('stripeLinter', function() {
+  this.timeout(20000);
+
+  test('lints API keys on file open', async () => {
+    const stripeLinter = new StripeLinter();
+    stripeLinter.activate();
+
+    const uris = await vscode.workspace.findFiles('apiKey.ts');
+    const uri = uris[0];
+    await vscode.window.showTextDocument(uri);
+    await sleep(2000); // wait for diagnostics to appear
+
+    const diagnostics = vscode.languages.getDiagnostics(uri);
+    assert.strictEqual(diagnostics.length, 1);
+    assert.strictEqual(diagnostics[0].message, 'This Stripe API Key is in a file not ignored by git. For better security, consider using a .env file. See https://stripe.com/docs/keys#safe-keys for more advice.');
+  });
+
+  test('lints API keys on file change', async () => {
+    const stripeLinter = new StripeLinter();
+    stripeLinter.activate();
+
+    const uris = await vscode.workspace.findFiles('apiKey.ts');
+    const uri = uris[0];
+
+    await vscode.window.showTextDocument(uri);
+    const editor = vscode.window.activeTextEditor;
+
+    if (editor) {
+      await editor.edit((editBuilder) => {
+        editBuilder.insert(
+          new vscode.Position(1, 0),
+          'const apiKey2 = \'sk_live_000000\';',
+        );
+      });
+    }
+
+    await sleep(2000); // wait for diagnostics to appear
+
+    const diagnostics = vscode.languages.getDiagnostics(uri);
+    assert.strictEqual(diagnostics.length, 2);
+    assert.strictEqual(diagnostics[1].message, 'This Stripe API Key is in a file not ignored by git. For better security, consider using a .env file. See https://stripe.com/docs/keys#safe-keys for more advice.');
+  });
+});

--- a/src/test/workspace/apiKey.ts
+++ b/src/test/workspace/apiKey.ts
@@ -1,0 +1,1 @@
+const apiKey = 'sk_test_000000';


### PR DESCRIPTION
# Summary
cc @stripe/developer-products 

API keys were only being linted when a document was saved. We now register the linter to lint on document open and document change, a better UX. This also fixes a bug where a recently created document would not be linted until the user saved it twice.

# Motivation
Fixes #67

# Testing
- Added tests
- Manually verified