### PR TITLE
Add timestamp tooltip to events view

### DIFF
--- a/src/stripeEventsView.ts
+++ b/src/stripeEventsView.ts
@@ -23,7 +23,8 @@ export class StripeEventsDataProvider extends StripeTreeViewDataProvider {
           const title = event.type;
           const eventItem = new StripeTreeItem(
             title,
-            'openEventDetails'
+            'openEventDetails',
+            new Date(event.created * 1000).toString(),
           );
           eventItem.metadata = {
             type: event.type,

--- a/src/stripeTreeItem.ts
+++ b/src/stripeTreeItem.ts
@@ -6,11 +6,12 @@ export class StripeTreeItem extends TreeItem {
   private _metadata: object | undefined;
   private commandString: string | undefined;
 
-  constructor(label: string, commandString?: string) {
+  constructor(label: string, commandString?: string, tooltip?: string) {
     super(label, TreeItemCollapsibleState.None);
     this.contextValue = 'stripe';
     this.commandString = commandString;
     this.metadata = {};
+    this.tooltip = tooltip;
   }
 
   // eslint-disable-next-line accessor-pairs


### PR DESCRIPTION
### Notify
cc @stripe/developer-products 

### Summary
Add timestamp on hover to the recent events list items.

<img width="688" alt="Screen Shot 2020-12-14 at 12 23 10 PM" src="https://user-images.githubusercontent.com/71457708/102420735-a4b7b500-3fb7-11eb-87f7-723a7ca2d246.png">

### Motivation
Resolves #74 .

### Testing
Manually verified that tooltip appears on hover.