### PR TITLE
Add text to the Help view that the extension runs in test mode.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -55,10 +55,11 @@ export function activate(this: any, context: ExtensionContext) {
     showCollapseAll: false,
   });
 
-  window.createTreeView('stripeHelpView', {
+  const stripeHelpView = window.createTreeView('stripeHelpView', {
     treeDataProvider: new StripeHelpViewDataProvider(),
     showCollapseAll: false,
   });
+  stripeHelpView.message = 'This extension runs with your Stripe account in test mode.';
 
   const stripeEventsViewProvider = new StripeEventsDataProvider(stripeClient);
   window.createTreeView('stripeEventsView', {


### PR DESCRIPTION
### Summary
Add a message 'This extension runs with your Stripe account in test mode.' to the Help view.
<img width="1136" alt="Screen Shot 2020-12-23 at 11 40 37 AM" src="https://user-images.githubusercontent.com/71457708/103031939-b1865c80-4513-11eb-82d0-7bc1663a866f.png">

### Motivation
Resolves #30.

### Testing
Manually verified that the text appears.