### PR TITLE
Add context menu to recent events list

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,6 +122,11 @@
       },
       {
         "category": "Stripe",
+        "command": "stripe.openDashboardEvent",
+        "title": "Open event in Dashboard"
+      },
+      {
+        "category": "Stripe",
         "command": "stripe.openDashboardEvents",
         "title": "Open Dashboard to see recent Events"
       },
@@ -163,6 +168,11 @@
         "category": "Stripe",
         "command": "stripe.openSurvey",
         "title": "Rate and provide feedback"
+      },
+      {
+        "category": "Stripe",
+        "command": "stripe.resendEvent",
+        "title": "Resend event"
       }
     ],
     "views": {
@@ -193,9 +203,27 @@
           "group": "navigation"
         }
       ],
+      "view/item/context": [
+        {
+          "command": "stripe.openDashboardEvent",
+          "when": "viewItem == eventItem"
+        },
+        {
+          "command": "stripe.resendEvent",
+          "when": "viewItem == eventItem"
+        }
+      ],
       "commandPalette": [
         {
+          "command": "stripe.openDashboardEvent",
+          "when": "false"
+        },
+        {
           "command": "stripe.openEventDetails",
+          "when": "false"
+        },
+        {
+          "command": "stripe.resendEvent",
           "when": "false"
         }
       ]

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -4,6 +4,7 @@ import {getExtensionInfo, showQuickPickWithValues} from './utils';
 import osName = require('os-name');
 import {StripeEventsDataProvider} from './stripeEventsView';
 import {StripeTerminal} from './stripeTerminal';
+import {StripeTreeItem} from './stripeTreeItem';
 import {Telemetry} from './telemetry';
 
 const telemetry = Telemetry.getInstance();
@@ -98,6 +99,14 @@ export function openDashboardApikeys() {
     vscode.Uri.parse('https://dashboard.stripe.com/test/apikeys')
   );
 }
+
+export function openDashboardEvent(stripeTreeItem: StripeTreeItem) {
+  telemetry.sendEvent('openDashboardEvent');
+  vscode.env.openExternal(
+    vscode.Uri.parse(`https://dashboard.stripe.com/test/events/${stripeTreeItem.metadata.id}`)
+  );
+}
+
 export function openDashboardEvents() {
   telemetry.sendEvent('openDashboardEvents');
   vscode.env.openExternal(
@@ -238,4 +247,9 @@ export function openTelemetryInfo() {
   vscode.env.openExternal(
     vscode.Uri.parse('https://code.visualstudio.com/docs/getstarted/telemetry')
   );
+}
+
+export function resendEvent(stripeTreeItem: StripeTreeItem) {
+  telemetry.sendEvent('resendEvent');
+  terminal.execute('events', ['resend', stripeTreeItem.metadata.id]);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,6 +3,7 @@ import {ServerOptions, TransportKind} from 'vscode-languageclient';
 import {
   openCLI,
   openDashboardApikeys,
+  openDashboardEvent,
   openDashboardEvents,
   openDashboardLogs,
   openDashboardWebhooks,
@@ -16,6 +17,7 @@ import {
   openWebhooksDebugConfigure,
   openWebhooksListen,
   refreshEventsList,
+  resendEvent,
   startLogin,
 } from './commands';
 import {Resource} from './resources';
@@ -179,6 +181,14 @@ export function activate(this: any, context: ExtensionContext) {
       'stripe.openWebhooksDebugConfigure',
       openWebhooksDebugConfigure
     )
+  );
+
+  subscriptions.push(
+    commands.registerCommand('stripe.resendEvent', resendEvent)
+  );
+
+  subscriptions.push(
+    commands.registerCommand('stripe.openDashboardEvent', openDashboardEvent)
   );
 }
 

--- a/src/stripeEventsView.ts
+++ b/src/stripeEventsView.ts
@@ -25,6 +25,7 @@ export class StripeEventsDataProvider extends StripeTreeViewDataProvider {
             title,
             'openEventDetails',
             new Date(event.created * 1000).toString(),
+            'eventItem',
           );
           eventItem.metadata = {
             type: event.type,

--- a/src/stripeTerminal.ts
+++ b/src/stripeTerminal.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import {OSType, filterAsync, findAsync, getOSType} from './utils';
 import psList from 'ps-list';
 
-type SupportedStripeCommand = 'listen' | 'logs' | 'login' | 'trigger';
+type SupportedStripeCommand = 'events' | 'listen' | 'logs' | 'login' | 'trigger';
 
 export class StripeTerminal {
   // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/src/stripeTreeItem.ts
+++ b/src/stripeTreeItem.ts
@@ -6,15 +6,17 @@ export class StripeTreeItem extends TreeItem {
   private _metadata: object | undefined;
   private commandString: string | undefined;
 
-  constructor(label: string, commandString?: string, tooltip?: string) {
+  constructor(label: string, commandString?: string, tooltip?: string, contextValue?: string) {
     super(label, TreeItemCollapsibleState.None);
     this.contextValue = 'stripe';
     this.commandString = commandString;
     this.metadata = {};
     this.tooltip = tooltip;
+    this.contextValue = contextValue;
   }
 
-  // eslint-disable-next-line accessor-pairs
+  get metadata() { return this._metadata; }
+
   set metadata(data: any) {
     this._metadata = data;
     if (this.commandString) {


### PR DESCRIPTION
### Notify
cc @stripe/developer-products 

### Summary

Right-click on a recent event to see a context menu:
- Open event in Dashboard
  - Externally opens `https://dashboard.stripe.com/test/events/<event>` in the user's browser.
- Resend event
  - Runs `stripe events resend <event>` in the user's VS Code terminal.

![Screen Shot 2021-01-05 at 9 44 27 AM](https://user-images.githubusercontent.com/71457708/103680187-a501fb00-4f3a-11eb-8b66-95e4db945baa.png)

![Screen Shot 2021-01-05 at 9 48 44 AM](https://user-images.githubusercontent.com/71457708/103680961-be577700-4f3b-11eb-9b18-4ddc5491b7fa.png)

https://user-images.githubusercontent.com/71457708/103680748-79334500-4f3b-11eb-8fe7-662e692816e6.mov

### Motivation
Resolves #71 

### Testing
Manually verified that the context menu shows up and both actions work as intended.