### PR TITLE
Add es2019 to typescript configuration

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "target": "es6",
+    "target": "es2019",
     "outDir": "out",
     "sourceMap": true,
     "strict": true,


### PR DESCRIPTION
### Notify
cc @stripe/developer-products 

### Summary
This change sets the target version of the typescript compiler to es2019 so we can make use of modern language features like `Array.prototype.flat()` and `Array.prototype.flatMap()`.

### Motivation
We are targeting VS Code version 1.44.0 as show in the `package.json`. Research shows this version supports es2019 [0], but we have been compiling the typescript source code to es6. As a result, we cannot make use of es2019 features like the `.flat()` method.

[0] [VS Code 1.44.0](https://github.com/microsoft/vscode/blob/1.44.0/package.json#L99) uses [Electron 7](https://www.electronjs.org/blog/electron-7-0), which uses [Node 12.8.1](https://node.green/#ES2019), which supports es2019.

### Testing
I added `console.log([[1], [2], [3]].flat())` to the source code and verified that my editor is now aware of the `.flat()` method. I verified that the typescript code compiles correctly by checking the output of the typescript compiler. I verified it works in runtime and when running `npm run test` as well.