### PR TITLE
Replace existing forms link with Stripe shortlink for feedback

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -239,7 +239,7 @@ export function openSurvey() {
     machineId: encodeURIComponent(vscode.env.machineId),
   });
 
-  const url = `https://forms.gle/eP2mtQ8Jmra4pZBP7?${query}`;
+  const url = `https://stri.pe/vscode-feedback?${query}`;
   vscode.env.openExternal(vscode.Uri.parse(url));
 }
 


### PR DESCRIPTION
Small change to replace the link to the feedback form with a short link: [stri.pe/vscode-feedback](https://stri.pe/vscode-feedback)


https://user-images.githubusercontent.com/58703040/104390679-1b7e9a00-54f3-11eb-8647-a03e54ebcf03.mov
