### PR TITLE
Recently used events appear on top of Trigger Events command (#77)

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -152,7 +152,7 @@ export function refreshEventsList(
 
 export async function openTriggerEvent(stripeClient: StripeClient) {
   telemetry.sendEvent('openTriggerEvent');
-  const events = await buildTriggerEventsList(allEvents, stripeClient);
+  const events = await buildTriggerEventsList(supportedEvents, stripeClient);
   const eventName = await showQuickPickWithItems('Enter event name to trigger', events);
   if (eventName) {
     terminal.execute('trigger', [eventName]);
@@ -170,7 +170,10 @@ export async function buildTriggerEventsList(events: string[], stripeClient: Str
 
   // Get a unique list of events and take the first 5
   const recentEvents = (historicEvents.data) ?
-    [...new Set<string>(historicEvents.data.map((e:any):string => e.type))].slice(0,5) : [];
+    [...new Set<string>(
+      historicEvents.data.map((e:any):string => e.type).filter((e: string) => events.includes(e))
+    )].slice(0,5) : [];
+
   const remainingEvents = events.filter((e) => !recentEvents.includes(e));
 
   const recentItems = recentEvents.map((e) => {
@@ -234,7 +237,7 @@ export function resendEvent(stripeTreeItem: StripeTreeItem) {
   terminal.execute('events', ['resend', stripeTreeItem.metadata.id]);
 }
 
-const allEvents: string[] = [
+const supportedEvents: string[] = [
   'balance.available',
   'charge.captured',
   'charge.dispute.created',

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -163,7 +163,7 @@ export function activate(this: any, context: ExtensionContext) {
   );
 
   subscriptions.push(
-    commands.registerCommand('stripe.openTriggerEvent', () => openTriggerEvent(stripeClient))
+    commands.registerCommand('stripe.openTriggerEvent', () => openTriggerEvent(context))
   );
 
   subscriptions.push(commands.registerCommand('stripe.openSurvey', openSurvey));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -163,7 +163,7 @@ export function activate(this: any, context: ExtensionContext) {
   );
 
   subscriptions.push(
-    commands.registerCommand('stripe.openTriggerEvent', openTriggerEvent)
+    commands.registerCommand('stripe.openTriggerEvent', () => openTriggerEvent(stripeClient))
   );
 
   subscriptions.push(commands.registerCommand('stripe.openSurvey', openSurvey));

--- a/src/stripeWorkspaceState.ts
+++ b/src/stripeWorkspaceState.ts
@@ -1,0 +1,22 @@
+import * as vscode from 'vscode';
+
+// Set a limit on the number of eventNames we store in context.
+const recentEventsLimit = 100;
+
+export const recentEventsKey = 'RecentEvents';
+
+export function getRecentEvents(extensionContext: vscode.ExtensionContext,
+  limit?: number): string[] {
+  const data: any = extensionContext.workspaceState.get(recentEventsKey, []);
+  return limit ? data.slice(0, limit) : data;
+}
+
+export function recordEvent(extensionContext: vscode.ExtensionContext, eventName: string) {
+  const eventsList = getRecentEvents(extensionContext);
+  const updatedList = [eventName].concat(eventsList).slice(0, recentEventsLimit);
+  extensionContext.workspaceState.update(recentEventsKey, updatedList);
+}
+
+export function clearRecordedEvents(extensionContext: vscode.ExtensionContext,) {
+  extensionContext.workspaceState.update(recentEventsKey, []);
+}

--- a/src/test/mocks/vscode.ts
+++ b/src/test/mocks/vscode.ts
@@ -1,0 +1,34 @@
+import * as vscode from 'vscode';
+
+export class TestMemento implements vscode.Memento {
+  storage: Map<string, any>;
+
+  constructor() {
+    this.storage = new Map();
+  }
+
+  public get(key:string, defaultValue?: any): any {
+    const data = this.storage.has(key) ? this.storage.get(key) : undefined;
+    return data ? data : defaultValue;
+  }
+
+  public update(key: string, value: any): Thenable<void> {
+    this.storage.set(key, value);
+    return Promise.resolve();
+  }
+
+}
+
+export const mocks = {
+  extensionContextMock: <vscode.ExtensionContext>{
+    subscriptions: [],
+    workspaceState: new TestMemento(),
+    globalState: new TestMemento(),
+    extensionPath: '',
+    asAbsolutePath: (relativePath: string) => '',
+    storagePath: '',
+    globalStoragePath: '',
+    logPath: ''
+  }
+};
+

--- a/src/test/suite/commands.test.ts
+++ b/src/test/suite/commands.test.ts
@@ -23,34 +23,50 @@ suite('commands', () => {
   });
 
   suite('buildTriggerEventsList',() => {
-    test('displays all original events when no recent events', async() => {
+    test('returns all original events when no recent events', async() => {
       const stripeClient = <StripeClient>{
         ...stripeClientStub,
       };
       const getEventsStub = createGetEventStub(stripeClient, []);
 
-      const allEvents = ['a', 'b', 'c', 'd', 'e'];
-      const events = await commands.buildTriggerEventsList(allEvents, stripeClient);
+      const supportedEvents = ['a', 'b', 'c', 'd', 'e'];
+      const events = await commands.buildTriggerEventsList(supportedEvents, stripeClient);
 
       assert.strictEqual(getEventsStub.calledOnce, true);
       const labels = events.map((x) => x.label);
-      assert.deepStrictEqual(labels, allEvents);
+      assert.deepStrictEqual(labels, supportedEvents);
     });
 
-    test('displays recent events on top', async() => {
+    test('returns recent events on top', async() => {
       const stripeClient = <StripeClient>{
         ...stripeClientStub,
       };
 
       const getEventsStub = createGetEventStub(stripeClient, ['c']);
 
-      const allEvents = ['a', 'b', 'c', 'd', 'e'];
-      const events = await commands.buildTriggerEventsList(allEvents, stripeClient);
+      const supportedEvents = ['a', 'b', 'c', 'd', 'e'];
+      const events = await commands.buildTriggerEventsList(supportedEvents, stripeClient);
 
       assert.strictEqual(getEventsStub.calledOnce, true);
       const labels = events.map((x) => x.label);
       assert.deepStrictEqual(labels, ['c', 'a', 'b', 'd', 'e']);
       assert.strictEqual(events[0].description, 'recently triggered');
+    });
+
+    test('does not include events that are not supported', async() => {
+      const stripeClient = <StripeClient>{
+        ...stripeClientStub,
+      };
+
+      const getEventsStub = createGetEventStub(stripeClient, ['c', 'unsupported']);
+      const supportedEvents = ['a', 'b', 'c', 'd', 'e'];
+      const events = await commands.buildTriggerEventsList(supportedEvents, stripeClient);
+
+      assert.strictEqual(getEventsStub.calledOnce, true);
+      const labels = events.map((x) => x.label);
+      assert.deepStrictEqual(labels, ['c', 'a', 'b', 'd', 'e']);
+      assert.strictEqual(events[0].description, 'recently triggered');
+
     });
 
     function createGetEventStub(stripeClient: StripeClient, eventNames: string[]) {
@@ -60,5 +76,4 @@ suite('commands', () => {
       return sandbox.stub(stripeClient, 'getEvents').returns(Promise.resolve(eventsData));
     }
   });
-
 });

--- a/src/test/suite/commands.test.ts
+++ b/src/test/suite/commands.test.ts
@@ -1,19 +1,11 @@
 import * as assert from 'assert';
 import * as commands from '../../commands';
 import * as sinon from 'sinon';
-
-import {StripeClient} from '../../stripeClient';
+import * as stripeState from '../../stripeWorkspaceState';
+import {mocks} from '../mocks/vscode';
 
 suite('commands', () => {
   let sandbox: sinon.SinonSandbox;
-  const stripeClientStub = <StripeClient> {
-    isInstalled: true,
-    cliPath: '',
-    detectInstalled: () => {},
-    getEvents: () => {},
-    getResourceById: (id: string) => {}
-  };
-
   setup(() => {
     sandbox = sinon.createSandbox();
   });
@@ -23,29 +15,24 @@ suite('commands', () => {
   });
 
   suite('buildTriggerEventsList',() => {
-    test('returns all original events when no recent events', async() => {
-      const stripeClient = <StripeClient>{
-        ...stripeClientStub,
-      };
-      const getEventsStub = createGetEventStub(stripeClient, []);
+    test('returns all original events when no recent events', () => {
+      const extensionContext = {...mocks.extensionContextMock};
+      const getEventsStub = sandbox.stub(stripeState, 'getRecentEvents').returns([]);
 
       const supportedEvents = ['a', 'b', 'c', 'd', 'e'];
-      const events = await commands.buildTriggerEventsList(supportedEvents, stripeClient);
+      const events = commands.buildTriggerEventsList(supportedEvents, extensionContext);
 
       assert.strictEqual(getEventsStub.calledOnce, true);
       const labels = events.map((x) => x.label);
       assert.deepStrictEqual(labels, supportedEvents);
     });
 
-    test('returns recent events on top', async() => {
-      const stripeClient = <StripeClient>{
-        ...stripeClientStub,
-      };
-
-      const getEventsStub = createGetEventStub(stripeClient, ['c']);
+    test('returns recent events on top', () => {
+      const extensionContext = {...mocks.extensionContextMock};
+      const getEventsStub = sandbox.stub(stripeState, 'getRecentEvents').returns(['c']);
 
       const supportedEvents = ['a', 'b', 'c', 'd', 'e'];
-      const events = await commands.buildTriggerEventsList(supportedEvents, stripeClient);
+      const events = commands.buildTriggerEventsList(supportedEvents, extensionContext);
 
       assert.strictEqual(getEventsStub.calledOnce, true);
       const labels = events.map((x) => x.label);
@@ -53,27 +40,17 @@ suite('commands', () => {
       assert.strictEqual(events[0].description, 'recently triggered');
     });
 
-    test('does not include events that are not supported', async() => {
-      const stripeClient = <StripeClient>{
-        ...stripeClientStub,
-      };
+    test('does not include events that are not supported', () => {
+      const extensionContext = {...mocks.extensionContextMock};
+      const getEventsStub = sandbox.stub(stripeState, 'getRecentEvents').returns(['c', 'unsupported']);
 
-      const getEventsStub = createGetEventStub(stripeClient, ['c', 'unsupported']);
       const supportedEvents = ['a', 'b', 'c', 'd', 'e'];
-      const events = await commands.buildTriggerEventsList(supportedEvents, stripeClient);
-
+      const events = commands.buildTriggerEventsList(supportedEvents, extensionContext);
       assert.strictEqual(getEventsStub.calledOnce, true);
       const labels = events.map((x) => x.label);
       assert.deepStrictEqual(labels, ['c', 'a', 'b', 'd', 'e']);
       assert.strictEqual(events[0].description, 'recently triggered');
 
     });
-
-    function createGetEventStub(stripeClient: StripeClient, eventNames: string[]) {
-      const eventsData = {
-        data: eventNames.map((l) => ({type: l}))
-      };
-      return sandbox.stub(stripeClient, 'getEvents').returns(Promise.resolve(eventsData));
-    }
   });
 });

--- a/src/test/suite/commands.test.ts
+++ b/src/test/suite/commands.test.ts
@@ -1,0 +1,64 @@
+import * as assert from 'assert';
+import * as commands from '../../commands';
+import * as sinon from 'sinon';
+
+import {StripeClient} from '../../stripeClient';
+
+suite('commands', () => {
+  let sandbox: sinon.SinonSandbox;
+  const stripeClientStub = <StripeClient> {
+    isInstalled: true,
+    cliPath: '',
+    detectInstalled: () => {},
+    getEvents: () => {},
+    getResourceById: (id: string) => {}
+  };
+
+  setup(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  teardown(() => {
+    sandbox.restore();
+  });
+
+  suite('buildTriggerEventsList',() => {
+    test('displays all original events when no recent events', async() => {
+      const stripeClient = <StripeClient>{
+        ...stripeClientStub,
+      };
+      const getEventsStub = createGetEventStub(stripeClient, []);
+
+      const allEvents = ['a', 'b', 'c', 'd', 'e'];
+      const events = await commands.buildTriggerEventsList(allEvents, stripeClient);
+
+      assert.strictEqual(getEventsStub.calledOnce, true);
+      const labels = events.map((x) => x.label);
+      assert.deepStrictEqual(labels, allEvents);
+    });
+
+    test('displays recent events on top', async() => {
+      const stripeClient = <StripeClient>{
+        ...stripeClientStub,
+      };
+
+      const getEventsStub = createGetEventStub(stripeClient, ['c']);
+
+      const allEvents = ['a', 'b', 'c', 'd', 'e'];
+      const events = await commands.buildTriggerEventsList(allEvents, stripeClient);
+
+      assert.strictEqual(getEventsStub.calledOnce, true);
+      const labels = events.map((x) => x.label);
+      assert.deepStrictEqual(labels, ['c', 'a', 'b', 'd', 'e']);
+      assert.strictEqual(events[0].description, 'recently triggered');
+    });
+
+    function createGetEventStub(stripeClient: StripeClient, eventNames: string[]) {
+      const eventsData = {
+        data: eventNames.map((l) => ({type: l}))
+      };
+      return sandbox.stub(stripeClient, 'getEvents').returns(Promise.resolve(eventsData));
+    }
+  });
+
+});

--- a/src/test/suite/stripeWorkspaceState.test.ts
+++ b/src/test/suite/stripeWorkspaceState.test.ts
@@ -1,0 +1,55 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+
+import {TestMemento, mocks} from '../mocks/vscode';
+import {getRecentEvents, recentEventsKey, recordEvent} from '../../stripeWorkspaceState';
+
+
+suite('RecentEvents', () => {
+  let sandbox: sinon.SinonSandbox;
+  setup(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  teardown(() => {
+    sandbox.restore();
+  });
+
+  test('getRecentEvents returns all events when limit is undefined', () => {
+    const workspaceState = new TestMemento();
+    const extensionContext = {...mocks.extensionContextMock, workspaceState: workspaceState};
+
+    const eventsList = ['a', 'b', 'c', 'd', 'e'];
+    workspaceState.update(recentEventsKey, eventsList);
+
+    const recentEvents = getRecentEvents(extensionContext);
+
+    assert.deepStrictEqual(recentEvents, eventsList);
+  });
+
+  test('getRecentEvents returns subset of events when limit is set', () => {
+    const workspaceState = new TestMemento();
+    const extensionContext = {...mocks.extensionContextMock, workspaceState: workspaceState};
+
+    const eventsList = ['a', 'b', 'c', 'd', 'e'];
+    workspaceState.update(recentEventsKey, eventsList);
+
+    const recentEvents = getRecentEvents(extensionContext, 2);
+
+    assert.deepStrictEqual(recentEvents, ['a', 'b']);
+  });
+
+  test('recordEvent adds event on top', () => {
+    const workspaceState = new TestMemento();
+    const extensionContext = {...mocks.extensionContextMock, workspaceState: workspaceState};
+
+    recordEvent(extensionContext, 'a');
+    recordEvent(extensionContext, 'b');
+    recordEvent(extensionContext, 'c');
+
+    const recentEvents = getRecentEvents(extensionContext);
+
+    assert.deepStrictEqual(recentEvents, ['c', 'b', 'a']);
+  });
+
+});

--- a/src/test/suite/utils.test.ts
+++ b/src/test/suite/utils.test.ts
@@ -1,8 +1,75 @@
 import * as assert from 'assert';
+import * as sinon from 'sinon';
 import * as utils from '../../utils';
+import * as vscode from 'vscode';
 
 suite('Utils', () => {
+
   const arr = [1, 2, 3];
+  let sandbox: sinon.SinonSandbox;
+
+  setup(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  teardown(() => {
+    sandbox.restore();
+  });
+
+  suite('showQuickPick', () => {
+    test('showQuickPickWithValues shows expected items and returns selected', async() => {
+      const quickPickInstance = vscode.window.createQuickPick();
+      const showSpy = sandbox.spy(quickPickInstance, 'show');
+      const createQuickPickStub = sandbox.stub(vscode.window, 'createQuickPick').returns(quickPickInstance);
+
+      const placeholder = 'I am placeholder text';
+      const itemValues = ['a', 'b', 'c'];
+
+      const selectedEvent = await (async () => {
+        const selected = utils.showQuickPickWithValues(placeholder, itemValues);
+        await vscode.commands.executeCommand('workbench.action.acceptSelectedQuickOpenItem');
+        return selected;
+      })();
+
+      assert.strictEqual(createQuickPickStub.calledOnce, true);
+      assert.strictEqual(showSpy.calledOnce, true);
+      assert.strictEqual(quickPickInstance.placeholder, placeholder);
+      const labels = quickPickInstance.items.map((x) => x.label);
+      assert.deepStrictEqual(labels, itemValues);
+      assert.strictEqual(selectedEvent, 'a');
+    });
+
+    test('showQuickPickWithItem shows expected items and returns selected', async() => {
+      const quickPickInstance = vscode.window.createQuickPick();
+      const showSpy = sandbox.spy(quickPickInstance, 'show');
+      const createQuickPickStub = sandbox.stub(vscode.window, 'createQuickPick').returns(quickPickInstance);
+
+      const placeholder = 'I am placeholder text';
+      const items = [{
+        label: 'test_label',
+        description: 'test_description',
+        detail: 'test_detail',
+        picked: false,
+        alwaysShow: false
+        }, {
+          label: 'another_label'
+        }
+      ];
+
+      const selectedEvent = await (async () => {
+        const selected = utils.showQuickPickWithItems(placeholder, items);
+        await vscode.commands.executeCommand('workbench.action.acceptSelectedQuickOpenItem');
+        return selected;
+      })();
+
+      assert.strictEqual(createQuickPickStub.calledOnce, true);
+      assert.strictEqual(showSpy.calledOnce, true);
+      assert.strictEqual(quickPickInstance.placeholder, placeholder);
+      assert.deepStrictEqual(quickPickInstance.items, items);
+      assert.strictEqual(selectedEvent, 'test_label');
+    });
+  });
+
 
   suite('findAsync', () => {
     test('Finds an item', async () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -32,17 +32,25 @@ export function getOSType(): OSType {
 
 export function showQuickPickWithValues(
   placeholder: string,
-  items: string[]
+  value: string[]
 ): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const input = vscode.window.createQuickPick();
-    input.placeholder = placeholder;
-    input.items = items.map((i) => {
+  const items:vscode.QuickPickItem[] = value.map((i) => {
       return {
         label: i,
       };
     });
 
+  return showQuickPickWithItems(placeholder, items);
+}
+
+export function showQuickPickWithItems(
+  placeholder: string,
+  items: vscode.QuickPickItem[]
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const input = vscode.window.createQuickPick();
+    input.placeholder = placeholder;
+    input.items = items;
     input.onDidAccept(() => {
       const value = input.selectedItems[0].label;
       resolve(value);


### PR DESCRIPTION
Adding a feature that allows recently triggered events to show up on top of the quickpick view. 

As of Rev 3: Recent Events is scoped to the events triggered through the VSCode extension. This will exclude all events triggered manually by the CLI.

In the entry of the workspace state, I set a hard limit of 100 because I figured we wouldn't gain much by storing more than that, and we want a method of cleaning out the data.