### PR TITLE
Update build action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,14 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-      
+
     - name: Use Node.js ${{ env.NODE_VERSION }}
       uses: actions/setup-node@v1
       with:
-        node-version: ${{ env.NODE_VERSION }}      
+        node-version: ${{ env.NODE_VERSION }}
 
-    - name: npm install, build, and test
+    - name: npm install, compile, and test
       run: |
         npm install
-        npm run build --if-present
-        npm run test --if-present
+        xvfb-run -a npm run compile --if-present
+        xvfb-run -a npm run test --if-present


### PR DESCRIPTION
- From the [VS Code docs](https://code.visualstudio.com/api/working-with-extensions/continuous-integration#github-actions), if we want to run VS Code in a Linux environment with GitHub Actions, we need to enable xvfb. I verified that this works on my personal fork of this repo.
- Replaced `build` with `compile` since we don't have a `build` script in our package.json.