### PR TITLE
Add GitHub action to automatically tag a new version

### DIFF
--- a/.github/workflows/auto_tags.yml
+++ b/.github/workflows/auto_tags.yml
@@ -1,0 +1,17 @@
+name: Auto tags
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  # Creates a new tag when the version specified in package.json changes
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: butlerlogic/action-autotag@stable
+      with:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        tag_prefix: "v"


### PR DESCRIPTION
Related to https://github.com/stripe/vscode-stripe/issues/123.

After changing `version` in the package.json, this action automatically detects the new version and creates a tag for it with a changelog.

Inspired by https://github.com/auchenberg/vscode-browser-preview/blob/master/.github/workflows/auto_tags.yml.