### PR TITLE
Add tests for detecting the user has the CLI installed at the default path

### DIFF
--- a/src/stripeClient.ts
+++ b/src/stripeClient.ts
@@ -1,12 +1,12 @@
 'use strict';
 
-import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import {OSType, getOSType} from './utils';
 import {Telemetry} from './telemetry';
 
 const execa = require('execa');
+const fs = require('fs');
 
 const telemetry = Telemetry.getInstance();
 

--- a/src/test/suite/stripeClient.test.ts
+++ b/src/test/suite/stripeClient.test.ts
@@ -1,0 +1,56 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import * as utils from '../../utils';
+import {StripeClient} from '../../stripeClient';
+
+const fs = require('fs');
+
+suite('stripeClient', () => {
+  let sandbox: sinon.SinonSandbox;
+
+  setup(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  teardown(() => {
+    sandbox.restore();
+  });
+
+  suite('detectInstalled', () => {
+    suite('with default CLI install path', () => {
+      const osPathPairs: [utils.OSType, string][] = [
+        [utils.OSType.linux, '/usr/local/bin/stripe'],
+        [utils.OSType.macOS, '/usr/local/bin/stripe'],
+        [utils.OSType.windows, 'scoop/shims/stripe.exe'],
+      ];
+
+      osPathPairs.forEach(([os, path]) => {
+        suite(`on ${os}`, () => {
+          let statSyncStub: sinon.SinonStub;
+
+          setup(() => {
+            sandbox.stub(utils, 'getOSType').returns(os);
+            statSyncStub = sandbox.stub(fs, 'statSync').withArgs(path);
+          });
+
+          test('detects installed', () => {
+            statSyncStub.returns(<any>{isFile: () => true});
+            const stripeClient = new StripeClient();
+            stripeClient.detectInstalled();
+            assert.deepStrictEqual(statSyncStub.args[0], [path]);
+            assert.strictEqual(stripeClient.isInstalled, true);
+            assert.strictEqual(stripeClient.cliPath, path);
+          });
+
+          test('detects not installed', () => {
+            statSyncStub.returns(<any>{isFile: () => false});
+            const stripeClient = new StripeClient();
+            stripeClient.detectInstalled();
+            assert.deepStrictEqual(statSyncStub.args[0], [path]);
+            assert.strictEqual(stripeClient.isInstalled, false);
+          });
+        });
+      });
+    });
+  });
+});

--- a/src/test/suite/stripeClient.test.ts
+++ b/src/test/suite/stripeClient.test.ts
@@ -34,7 +34,7 @@ suite('stripeClient', () => {
           });
 
           test('detects installed', () => {
-            statSyncStub.returns(<any>{isFile: () => true});
+            statSyncStub.returns(<any>{isFile: () => true}); // the path is a file; CLI found
             const stripeClient = new StripeClient();
             stripeClient.detectInstalled();
             assert.deepStrictEqual(statSyncStub.args[0], [path]);
@@ -43,7 +43,7 @@ suite('stripeClient', () => {
           });
 
           test('detects not installed', () => {
-            statSyncStub.returns(<any>{isFile: () => false});
+            statSyncStub.returns(<any>{isFile: () => false}); // the path is not a file; CLI not found
             const stripeClient = new StripeClient();
             stripeClient.detectInstalled();
             assert.deepStrictEqual(statSyncStub.args[0], [path]);


### PR DESCRIPTION
### Notify
@stripe/developer-products 

### Summary
Add tests that verify that `StripeClient` can detect when the CLI is installed at the default path.

### Motivation
In preparation for fixing https://github.com/stripe/vscode-stripe/issues/133, which involves detecting that the CLI is installed at a custom path.

### Testing
Verify that the tests are testing the right thing by intentionally causing them to fail, then succeed.