### PR TITLE
Adding ability to inject specific implementations of Telemetry into unit tests

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -3,12 +3,12 @@ import * as vscode from 'vscode';
 import {getExtensionInfo, showQuickPickWithItems, showQuickPickWithValues} from './utils';
 import {getRecentEvents, recordEvent} from './stripeWorkspaceState';
 import osName = require('os-name');
+import {GATelemetry} from './telemetry';
 import {StripeEventsDataProvider} from './stripeEventsView';
 import {StripeTerminal} from './stripeTerminal';
 import {StripeTreeItem} from './stripeTreeItem';
-import {Telemetry} from './telemetry';
 
-const telemetry = Telemetry.getInstance();
+const telemetry = GATelemetry.getInstance();
 
 const terminal = new StripeTerminal();
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,6 +20,7 @@ import {
   resendEvent,
   startLogin,
 } from './commands';
+import {GATelemetry} from './telemetry';
 import {Resource} from './resources';
 import {StripeClient} from './stripeClient';
 import {StripeDashboardViewDataProvider} from './stripeDashboardView';
@@ -31,20 +32,19 @@ import {StripeLanguageClient} from './stripeLanguageServer/client';
 import {StripeLinter} from './stripeLinter';
 import {StripeLogsDataProvider} from './stripeLogsView';
 import {SurveyPrompt} from './surveyPrompt';
-import {Telemetry} from './telemetry';
 import {TelemetryPrompt} from './telemetryPrompt';
 import path from 'path';
 
 export function activate(this: any, context: ExtensionContext) {
-  // Stripe CLi client
-  const stripeClient = new StripeClient();
-
   // disclosure of telemetry prompt
   new TelemetryPrompt(context).activate();
 
   // Telemetry
-  const telemetry = Telemetry.getInstance();
+  const telemetry = GATelemetry.getInstance();
   telemetry.sendEvent('activate');
+
+  // Stripe CLi client
+  const stripeClient = new StripeClient(telemetry);
 
   // CSAT survey prompt
   new SurveyPrompt(context).activate();
@@ -76,7 +76,7 @@ export function activate(this: any, context: ExtensionContext) {
   });
 
   // Debug provider
-  debug.registerDebugConfigurationProvider('stripe', new StripeDebugProvider());
+  debug.registerDebugConfigurationProvider('stripe', new StripeDebugProvider(telemetry));
 
   // Virtual document content provider for displaying event data
   workspace.registerTextDocumentContentProvider(
@@ -104,7 +104,7 @@ export function activate(this: any, context: ExtensionContext) {
     },
   };
 
-  StripeLanguageClient.activate(context, serverOptions);
+  StripeLanguageClient.activate(context, serverOptions, telemetry);
 
   // Commands
   const subscriptions = context.subscriptions;

--- a/src/stripeClient.ts
+++ b/src/stripeClient.ts
@@ -13,14 +13,11 @@ export class StripeClient {
   isInstalled: boolean;
   cliPath: string | null;
 
-  constructor(telemetry: Telemetry) {
+  constructor(telemetry:Telemetry) {
     this.telemetry = telemetry;
     this.isInstalled = false;
     this.cliPath = null;
-    vscode.workspace.onDidChangeConfiguration(
-      this.handleDidChangeConfiguration,
-      this
-    );
+    vscode.workspace.onDidChangeConfiguration(this.handleDidChangeConfiguration, this);
   }
 
   private async execute(command: string) {
@@ -68,9 +65,7 @@ export class StripeClient {
     );
 
     if (returnValue === actionText) {
-      vscode.env.openExternal(
-        vscode.Uri.parse('https://stripe.com/docs/stripe-cli')
-      );
+      vscode.env.openExternal(vscode.Uri.parse('https://stripe.com/docs/stripe-cli'));
     }
   }
 
@@ -130,7 +125,7 @@ export class StripeClient {
 
     const installPath = customInstallPath || defaultInstallPath;
 
-    if (installPath && (await isFile(installPath))) {
+    if (installPath && await isFile(installPath)) {
       this.cliPath = installPath;
       return true;
     }
@@ -156,9 +151,7 @@ export class StripeClient {
     return resource;
   }
 
-  private async handleDidChangeConfiguration(
-    e: vscode.ConfigurationChangeEvent
-  ) {
+  private async handleDidChangeConfiguration(e: vscode.ConfigurationChangeEvent) {
     const shouldHandleConfigurationChange = e.affectsConfiguration('stripe');
     if (shouldHandleConfigurationChange) {
       const isAuthenticated = await this.isAuthenticated();

--- a/src/stripeClient.ts
+++ b/src/stripeClient.ts
@@ -8,13 +8,13 @@ import {Telemetry} from './telemetry';
 const execa = require('execa');
 const fs = require('fs');
 
-const telemetry = Telemetry.getInstance();
-
 export class StripeClient {
+  telemetry: Telemetry;
   isInstalled: boolean;
   cliPath: string;
 
-  constructor() {
+  constructor(telemetry:Telemetry) {
+    this.telemetry = telemetry;
     this.isInstalled = false;
     this.cliPath = '';
     vscode.workspace.onDidChangeConfiguration(this.handleDidChangeConfiguration, this);
@@ -36,7 +36,7 @@ export class StripeClient {
     }
 
     const flags: object[] = [];
-    if (!telemetry.isTelemetryEnabled) {
+    if (!this.telemetry.isTelemetryEnabled()) {
       flags.push({
         // eslint-disable-next-line @typescript-eslint/naming-convention
         STRIPE_CLI_TELEMETRY_OPTOUT: true,
@@ -93,10 +93,10 @@ export class StripeClient {
       if (hasConfigForProject) {
         return true;
       }
-      telemetry.sendEvent('cli.notAuthenticated');
+      this.telemetry.sendEvent('cli.notAuthenticated');
       return false;
     } catch (err) {
-      telemetry.sendEvent('cli.notAuthenticated');
+      this.telemetry.sendEvent('cli.notAuthenticated');
       return false;
     }
   }
@@ -143,7 +143,7 @@ export class StripeClient {
       this.cliPath = validInstallPath;
     } else {
       this.isInstalled = false;
-      telemetry.sendEvent('cli.notInstalled');
+      this.telemetry.sendEvent('cli.notInstalled');
     }
   }
 

--- a/src/stripeClient.ts
+++ b/src/stripeClient.ts
@@ -11,19 +11,22 @@ const fs = require('fs');
 export class StripeClient {
   telemetry: Telemetry;
   isInstalled: boolean;
-  cliPath: string;
+  cliPath: string | null;
 
-  constructor(telemetry:Telemetry) {
+  constructor(telemetry: Telemetry) {
     this.telemetry = telemetry;
     this.isInstalled = false;
-    this.cliPath = '';
-    vscode.workspace.onDidChangeConfiguration(this.handleDidChangeConfiguration, this);
+    this.cliPath = null;
+    vscode.workspace.onDidChangeConfiguration(
+      this.handleDidChangeConfiguration,
+      this
+    );
   }
 
   private async execute(command: string) {
-    this.detectInstalled();
+    const isInstalled = await this.detectInstalled();
 
-    if (!this.isInstalled) {
+    if (!isInstalled) {
       this.promptInstall();
       return;
     }
@@ -65,7 +68,9 @@ export class StripeClient {
     );
 
     if (returnValue === actionText) {
-      vscode.env.openExternal(vscode.Uri.parse('https://stripe.com/docs/stripe-cli'));
+      vscode.env.openExternal(
+        vscode.Uri.parse('https://stripe.com/docs/stripe-cli')
+      );
     }
   }
 
@@ -101,50 +106,44 @@ export class StripeClient {
     }
   }
 
-  detectInstalled() {
-    const osType: OSType = getOSType();
-    let installPaths: string[] = [];
-
-    switch (osType) {
-      case OSType.macOS:
-        // HomeBrew install path on macOS
-        installPaths = ['/usr/local/bin/stripe'];
-        break;
-      case OSType.linux:
-        // apt-get install path on ubuntu + yum install path on centOS
-        installPaths = ['/usr/local/bin/stripe'];
-        break;
-      case OSType.windows:
-        // scoop install path on Windows 10
-        const userProfile = process.env.USERPROFILE || '';
-        installPaths = [path.join(userProfile, 'scoop', 'shims', 'stripe.exe')];
-        break;
-    }
-
-    // Handle custom CLI path setting
-    const config = vscode.workspace.getConfiguration('stripe');
-    if (config) {
-      const cliInstallPath = config.get<string>('cliInstallPath');
-      if (cliInstallPath) {
-        const validInstallPath = getInstallPath([cliInstallPath]);
-        if (!validInstallPath) {
-          vscode.window.showErrorMessage(
-            `You set a custom installation path for the Stripe CLI, but we couldn't find the executable in '${cliInstallPath}'`,
-            ...['Ok']
-          );
-        }
+  async detectInstalled() {
+    const defaultInstallPath = (() => {
+      const osType: OSType = getOSType();
+      switch (osType) {
+        case OSType.macOS:
+          // HomeBrew install path on macOS
+          return '/usr/local/bin/stripe';
+        case OSType.linux:
+          // apt-get install path on ubuntu + yum install path on centOS
+          return '/usr/local/bin/stripe';
+        case OSType.windows:
+          // scoop install path on Windows 10
+          const userProfile = process.env.USERPROFILE || '';
+          return path.join(userProfile, 'scoop', 'shims', 'stripe.exe');
+        default:
+          return null;
       }
+    })();
+
+    const config = vscode.workspace.getConfiguration('stripe');
+    const customInstallPath = config.get('cliInstallPath', null);
+
+    const installPath = customInstallPath || defaultInstallPath;
+
+    if (installPath && (await isFile(installPath))) {
+      this.cliPath = installPath;
+      return true;
     }
 
-    const validInstallPath = getInstallPath(installPaths);
-
-    if (validInstallPath) {
-      this.isInstalled = true;
-      this.cliPath = validInstallPath;
-    } else {
-      this.isInstalled = false;
-      this.telemetry.sendEvent('cli.notInstalled');
+    if (customInstallPath) {
+      vscode.window.showErrorMessage(
+        `You set a custom installation path for the Stripe CLI, but we couldn't find the executable in '${customInstallPath}'`,
+        ...['Ok']
+      );
     }
+    this.cliPath = null;
+    this.telemetry.sendEvent('cli.notInstalled');
+    return false;
   }
 
   getEvents() {
@@ -157,7 +156,9 @@ export class StripeClient {
     return resource;
   }
 
-  private async handleDidChangeConfiguration(e: vscode.ConfigurationChangeEvent) {
+  private async handleDidChangeConfiguration(
+    e: vscode.ConfigurationChangeEvent
+  ) {
     const shouldHandleConfigurationChange = e.affectsConfiguration('stripe');
     if (shouldHandleConfigurationChange) {
       const isAuthenticated = await this.isAuthenticated();
@@ -168,17 +169,12 @@ export class StripeClient {
   }
 }
 
-function getInstallPath(paths: string[]): string {
-  for (let i = 0; i < paths.length; i++) {
-    const path = paths[i];
-    try {
-      // eslint-disable-next-line no-sync
-      const isValidPath = fs.statSync(path).isFile();
-      if (isValidPath) {
-        return path;
-      }
-    } catch (err) {}
+async function isFile(path: string): Promise<boolean> {
+  try {
+    const resolvedPath = await fs.promises.realpath(path);
+    const fileStat = await fs.promises.stat(resolvedPath);
+    return fileStat.isFile();
+  } catch (err) {
+    return false;
   }
-
-  return '';
 }

--- a/src/stripeDebugProvider.ts
+++ b/src/stripeDebugProvider.ts
@@ -2,10 +2,11 @@
 import * as vscode from 'vscode';
 import {Telemetry} from './telemetry';
 
-const telemetry = Telemetry.getInstance();
-
 export class StripeDebugProvider implements vscode.DebugConfigurationProvider {
-  constructor() {
+  telemetry: Telemetry;
+
+  constructor(telemetry: Telemetry) {
+    this.telemetry = telemetry;
     vscode.debug.onDidTerminateDebugSession((e: vscode.DebugSession) => {
       if (e.name === 'Stripe: Webhooks listen') {
         // TODO: Find a way to stop the CLI from the given debug session.
@@ -25,7 +26,7 @@ export class StripeDebugProvider implements vscode.DebugConfigurationProvider {
         config.command &&
         config.command === 'listen'
       ) {
-        telemetry.sendEvent('debug.launch');
+        this.telemetry.sendEvent('debug.launch');
 
         vscode.commands.executeCommand('stripe.openWebhooksListen', {
           forwardTo: config.forwardTo,

--- a/src/stripeLanguageServer/client.ts
+++ b/src/stripeLanguageServer/client.ts
@@ -8,10 +8,8 @@ import {
 
 import {Telemetry} from '../telemetry';
 
-const telemetry = Telemetry.getInstance();
-
 export class StripeLanguageClient {
-  static activate(context: ExtensionContext, serverOptions: ServerOptions) {
+  static activate(context: ExtensionContext, serverOptions: ServerOptions, telemetry: Telemetry) {
     const clientOptions: LanguageClientOptions = {
       // Register the server for javascript (more languages to come)
       documentSelector: [{scheme: 'file', language: 'javascript'}, {scheme: 'file', language: 'typescript'}],

--- a/src/stripeLinter.ts
+++ b/src/stripeLinter.ts
@@ -9,9 +9,9 @@ import {
   workspace,
 } from 'vscode';
 
-import {Telemetry} from './telemetry';
+import {GATelemetry} from './telemetry';
 
-const telemetry = Telemetry.getInstance();
+const telemetry = GATelemetry.getInstance();
 
 interface Resource {
   uri: {

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -4,8 +4,34 @@ import ua from 'universal-analytics';
 const osName = require('os-name');
 const publicIp = require('public-ip');
 
-export class Telemetry {
-  private static INSTANCE: Telemetry;
+export interface Telemetry {
+  sendEvent(eventName: string, eventValue?: any): void;
+  isTelemetryEnabled(): boolean;
+}
+
+// A NoOp implementation of telemetry
+export class NoOpTelemetry implements Telemetry {
+  sendEvent(eventName: string, eventValue?: any) {}
+
+  isTelemetryEnabled() {
+    return true;
+  }
+}
+
+// A Local implementation of telemetry
+export class LocalTelemetry implements Telemetry {
+  sendEvent(eventName: string, eventValue?: any) {
+    console.log('[TelemetryEvent] %s: %s', eventName, eventValue);
+  }
+
+  isTelemetryEnabled() {
+    return true;
+  }
+}
+
+// Google Auth Implementation of Telemetry
+export class GATelemetry implements Telemetry {
+  private static INSTANCE: GATelemetry;
 
   client: any;
   userId: string;
@@ -21,14 +47,14 @@ export class Telemetry {
   }
 
   public static getInstance(): Telemetry {
-    if (!Telemetry.INSTANCE) {
-      Telemetry.INSTANCE = new Telemetry();
+    if (!GATelemetry.INSTANCE) {
+      GATelemetry.INSTANCE = new GATelemetry();
     }
 
-    return Telemetry.INSTANCE;
+    return GATelemetry.INSTANCE;
   }
 
-  get isTelemetryEnabled(): boolean {
+  isTelemetryEnabled(): boolean {
     return this._isTelemetryEnabled;
   }
 

--- a/src/test/suite/stripeClient.test.ts
+++ b/src/test/suite/stripeClient.test.ts
@@ -29,13 +29,13 @@ suite('stripeClient', () => {
 
       osPathPairs.forEach(([os, path]) => {
         suite(`on ${os}`, () => {
+
           let realpathStub: sinon.SinonStub;
           let statStub: sinon.SinonStub;
 
           setup(() => {
             sandbox.stub(utils, 'getOSType').returns(os);
-            realpathStub = sandbox
-              .stub(fs.promises, 'realpath')
+            realpathStub = sandbox.stub(fs.promises, 'realpath')
               .withArgs(path)
               .returns(Promise.resolve(resolvedPath));
             statStub = sandbox.stub(fs.promises, 'stat').withArgs(resolvedPath);
@@ -65,11 +65,7 @@ suite('stripeClient', () => {
     });
 
     suite('with custom CLI install path', () => {
-      const osTypes = [
-        utils.OSType.linux,
-        utils.OSType.macOS,
-        utils.OSType.windows,
-      ];
+      const osTypes = [utils.OSType.linux, utils.OSType.macOS, utils.OSType.windows];
       const customPath = '/foo/bar/baz';
       const resolvedPath = '/resolved/path/to/stripe';
 
@@ -77,15 +73,14 @@ suite('stripeClient', () => {
       let statStub: sinon.SinonStub;
 
       setup(() => {
-        sandbox
-          .stub(vscode.workspace, 'getConfiguration')
+        sandbox.stub(vscode.workspace, 'getConfiguration')
           .withArgs('stripe')
           .returns(<any>{get: () => customPath});
-        realpathStub = sandbox
-          .stub(fs.promises, 'realpath')
+        realpathStub = sandbox.stub(fs.promises, 'realpath')
           .withArgs(customPath)
           .returns(Promise.resolve(resolvedPath));
         statStub = sandbox.stub(fs.promises, 'stat').withArgs(resolvedPath);
+
       });
 
       osTypes.forEach((os) => {

--- a/src/test/suite/stripeClient.test.ts
+++ b/src/test/suite/stripeClient.test.ts
@@ -1,6 +1,7 @@
 import * as assert from 'assert';
 import * as sinon from 'sinon';
 import * as utils from '../../utils';
+import {NoOpTelemetry} from '../../telemetry';
 import {StripeClient} from '../../stripeClient';
 
 const fs = require('fs');
@@ -35,7 +36,7 @@ suite('stripeClient', () => {
 
           test('detects installed', () => {
             statSyncStub.returns(<any>{isFile: () => true}); // the path is a file; CLI found
-            const stripeClient = new StripeClient();
+            const stripeClient = new StripeClient(new NoOpTelemetry());
             stripeClient.detectInstalled();
             assert.deepStrictEqual(statSyncStub.args[0], [path]);
             assert.strictEqual(stripeClient.isInstalled, true);
@@ -44,7 +45,7 @@ suite('stripeClient', () => {
 
           test('detects not installed', () => {
             statSyncStub.returns(<any>{isFile: () => false}); // the path is not a file; CLI not found
-            const stripeClient = new StripeClient();
+            const stripeClient = new StripeClient(new NoOpTelemetry());
             stripeClient.detectInstalled();
             assert.deepStrictEqual(statSyncStub.args[0], [path]);
             assert.strictEqual(stripeClient.isInstalled, false);

--- a/src/test/suite/stripeClient.test.ts
+++ b/src/test/suite/stripeClient.test.ts
@@ -1,6 +1,7 @@
 import * as assert from 'assert';
 import * as sinon from 'sinon';
 import * as utils from '../../utils';
+import * as vscode from 'vscode';
 import {NoOpTelemetry} from '../../telemetry';
 import {StripeClient} from '../../stripeClient';
 
@@ -24,31 +25,93 @@ suite('stripeClient', () => {
         [utils.OSType.macOS, '/usr/local/bin/stripe'],
         [utils.OSType.windows, 'scoop/shims/stripe.exe'],
       ];
+      const resolvedPath = '/resolved/path/to/stripe';
 
       osPathPairs.forEach(([os, path]) => {
         suite(`on ${os}`, () => {
-          let statSyncStub: sinon.SinonStub;
+          let realpathStub: sinon.SinonStub;
+          let statStub: sinon.SinonStub;
 
           setup(() => {
             sandbox.stub(utils, 'getOSType').returns(os);
-            statSyncStub = sandbox.stub(fs, 'statSync').withArgs(path);
+            realpathStub = sandbox
+              .stub(fs.promises, 'realpath')
+              .withArgs(path)
+              .returns(Promise.resolve(resolvedPath));
+            statStub = sandbox.stub(fs.promises, 'stat').withArgs(resolvedPath);
           });
 
-          test('detects installed', () => {
-            statSyncStub.returns(<any>{isFile: () => true}); // the path is a file; CLI found
+          test('detects installed', async () => {
+            statStub.returns(Promise.resolve({isFile: () => true})); // the path is a file; CLI found
             const stripeClient = new StripeClient(new NoOpTelemetry());
-            stripeClient.detectInstalled();
-            assert.deepStrictEqual(statSyncStub.args[0], [path]);
-            assert.strictEqual(stripeClient.isInstalled, true);
+            const isInstalled = await stripeClient.detectInstalled();
+            assert.strictEqual(isInstalled, true);
+            assert.deepStrictEqual(realpathStub.args[0], [path]);
+            assert.deepStrictEqual(statStub.args[0], [resolvedPath]);
             assert.strictEqual(stripeClient.cliPath, path);
           });
 
-          test('detects not installed', () => {
-            statSyncStub.returns(<any>{isFile: () => false}); // the path is not a file; CLI not found
+          test('detects not installed', async () => {
+            statStub.returns(Promise.resolve({isFile: () => false})); // the path is not a file; CLI not found
             const stripeClient = new StripeClient(new NoOpTelemetry());
-            stripeClient.detectInstalled();
-            assert.deepStrictEqual(statSyncStub.args[0], [path]);
-            assert.strictEqual(stripeClient.isInstalled, false);
+            const isInstalled = await stripeClient.detectInstalled();
+            assert.strictEqual(isInstalled, false);
+            assert.deepStrictEqual(realpathStub.args[0], [path]);
+            assert.deepStrictEqual(statStub.args[0], [resolvedPath]);
+            assert.strictEqual(stripeClient.cliPath, null);
+          });
+        });
+      });
+    });
+
+    suite('with custom CLI install path', () => {
+      const osTypes = [
+        utils.OSType.linux,
+        utils.OSType.macOS,
+        utils.OSType.windows,
+      ];
+      const customPath = '/foo/bar/baz';
+      const resolvedPath = '/resolved/path/to/stripe';
+
+      let realpathStub: sinon.SinonStub;
+      let statStub: sinon.SinonStub;
+
+      setup(() => {
+        sandbox
+          .stub(vscode.workspace, 'getConfiguration')
+          .withArgs('stripe')
+          .returns(<any>{get: () => customPath});
+        realpathStub = sandbox
+          .stub(fs.promises, 'realpath')
+          .withArgs(customPath)
+          .returns(Promise.resolve(resolvedPath));
+        statStub = sandbox.stub(fs.promises, 'stat').withArgs(resolvedPath);
+      });
+
+      osTypes.forEach((os) => {
+        suite(`on ${os}`, () => {
+          setup(() => {
+            sandbox.stub(utils, 'getOSType').returns(os);
+          });
+
+          test('detects installed', async () => {
+            statStub.returns(Promise.resolve({isFile: () => true})); // the path is a file; CLI found
+            const stripeClient = new StripeClient(new NoOpTelemetry());
+            const isInstalled = await stripeClient.detectInstalled();
+            assert.strictEqual(isInstalled, true);
+            assert.deepStrictEqual(realpathStub.args[0], [customPath]);
+            assert.deepStrictEqual(statStub.args[0], [resolvedPath]);
+            assert.strictEqual(stripeClient.cliPath, customPath);
+          });
+
+          test('detects not installed', async () => {
+            statStub.returns(Promise.resolve({isFile: () => false})); // the path is not a file; CLI not found
+            const stripeClient = new StripeClient(new NoOpTelemetry());
+            const isInstalled = await stripeClient.detectInstalled();
+            assert.strictEqual(isInstalled, false);
+            assert.deepStrictEqual(realpathStub.args[0], [customPath]);
+            assert.deepStrictEqual(statStub.args[0], [resolvedPath]);
+            assert.strictEqual(stripeClient.cliPath, null);
           });
         });
       });

--- a/src/test/suite/telemetry.test.ts
+++ b/src/test/suite/telemetry.test.ts
@@ -1,10 +1,10 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
-import {Telemetry} from '../../telemetry';
+import {GATelemetry} from '../../telemetry';
 
-suite('Telemetry', function () {
+suite('GATelemetry', function () {
   this.timeout(20000);
-  const telemetry = Telemetry.getInstance();
+  const telemetry = GATelemetry.getInstance();
 
   suite('Telemetry configs', () => {
     test('Respects overall and Stripe-specific telemetry configs', async () => {
@@ -14,19 +14,19 @@ suite('Telemetry', function () {
 
       await telemetryConfig.update('enableTelemetry', false);
       await stripeTelemetryConfig.update('enabled', false);
-      assert.strictEqual(telemetry.isTelemetryEnabled, false);
+      assert.strictEqual(telemetry.isTelemetryEnabled(), false);
 
       await telemetryConfig.update('enableTelemetry', false);
       await stripeTelemetryConfig.update('enabled', true);
-      assert.strictEqual(telemetry.isTelemetryEnabled, false);
+      assert.strictEqual(telemetry.isTelemetryEnabled(), false);
 
       await telemetryConfig.update('enableTelemetry', true);
       await stripeTelemetryConfig.update('enabled', false);
-      assert.strictEqual(telemetry.isTelemetryEnabled, false);
+      assert.strictEqual(telemetry.isTelemetryEnabled(), false);
 
       await telemetryConfig.update('enableTelemetry', true);
       await stripeTelemetryConfig.update('enabled', true);
-      assert.strictEqual(telemetry.isTelemetryEnabled, true);
+      assert.strictEqual(telemetry.isTelemetryEnabled(), true);
     });
   });
 });


### PR DESCRIPTION
This PR converts the Telemetry class into an interface and consolidates the responsibility of creating a telemetry instance to the extensions class. This paves the way for [#131](https://github.com/stripe/vscode-stripe/issues/131). In this commit, we prevent the stripeClient unit tests from emitting data to Google Analytics by passing in a NoOp.

Commands and StripeLinter will be updated in a following PR. Those are a bit trickier to untangle. 
