### PR TITLE
Injecting instance of Telemetry into Commands

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -3,281 +3,285 @@ import * as vscode from 'vscode';
 import {getExtensionInfo, showQuickPickWithItems, showQuickPickWithValues} from './utils';
 import {getRecentEvents, recordEvent} from './stripeWorkspaceState';
 import osName = require('os-name');
-import {GATelemetry} from './telemetry';
 import {StripeEventsDataProvider} from './stripeEventsView';
 import {StripeTerminal} from './stripeTerminal';
 import {StripeTreeItem} from './stripeTreeItem';
+import {Telemetry} from './telemetry';
 
-const telemetry = GATelemetry.getInstance();
+export class Commands {
+  telemetry: Telemetry;
+  terminal: StripeTerminal;
 
-const terminal = new StripeTerminal();
+  supportedEvents: string[] = [
+    'balance.available',
+    'charge.captured',
+    'charge.dispute.created',
+    'charge.failed',
+    'charge.refunded',
+    'charge.succeeded',
+    'checkout.session.completed',
+    'customer.created',
+    'customer.deleted',
+    'customer.source.created',
+    'customer.source.updated',
+    'customer.subscription.created',
+    'customer.subscription.deleted',
+    'customer.subscription.updated',
+    'customer.updated',
+    'invoice.created',
+    'invoice.finalized',
+    'invoice.payment_failed',
+    'invoice.payment_succeeded',
+    'invoice.updated',
+    'issuing_authorization.request',
+    'issuing_card.created',
+    'issuing_cardholder.created',
+    'payment_intent.amount_capturable_updated',
+    'payment_intent.canceled',
+    'payment_intent.created',
+    'payment_intent.payment_failed',
+    'payment_intent.succeeded',
+    'payment_method.attached',
+    'plan.created',
+    'plan.deleted',
+    'plan.updated',
+    'product.created',
+    'product.deleted',
+    'product.updated',
+    'setup_intent.canceled',
+    'setup_intent.created',
+    'setup_intent.setup_failed',
+    'setup_intent.succeeded',
+    'subscription_schedule.canceled',
+    'subscription_schedule.created',
+    'subscription_schedule.released',
+    'subscription_schedule.updated',
+  ];
 
-export async function openWebhooksListen(options: any) {
-  telemetry.sendEvent('openWebhooksListen');
+  constructor(telemetry: Telemetry, terminal: StripeTerminal, supportedEvents?: string[]) {
+    this.telemetry = telemetry;
+    this.terminal = terminal;
+    if (supportedEvents) {
+      this.supportedEvents = supportedEvents;
+    }
+  }
 
-  const shouldPromptForURL = !options.forwardTo && !options.forwardConnectTo &&
-    await showQuickPickWithValues(
-      'Do you want to forward webhook events to your local server?',
-      ['Yes', 'No']
-    ) === 'Yes';
+  openWebhooksListen = async (options: any) => {
+    this.telemetry.sendEvent('openWebhooksListen');
 
-  const forwardTo = shouldPromptForURL
+    const shouldPromptForURL = !options.forwardTo && !options.forwardConnectTo &&
+      await showQuickPickWithValues(
+        'Do you want to forward webhook events to your local server?',
+        ['Yes', 'No']
+      ) === 'Yes';
+
+    const forwardTo = shouldPromptForURL
     ? await vscode.window.showInputBox(
         {
           prompt: 'Enter local server URL to forward webhook events to',
           value: 'http://localhost:3000',
         }
       )
-    : options.forwardTo;
+      : options.forwardTo;
 
-  const forwardConnectTo = shouldPromptForURL
+    const forwardConnectTo = shouldPromptForURL
     ? await vscode.window.showInputBox(
         {
-          prompt: 'Enter local server URL to forward Connect webhook events to (default: same as normal events)',
+          prompt:
+            'Enter local server URL to forward Connect webhook events to (default: same as normal events)',
           value: forwardTo || 'http://localhost:3000',
         }
       )
-    : options.forwardConnectTo;
+      : options.forwardConnectTo;
 
-  const invalidURLCharsRE = /[^\w-.~:\/?#\[\]@!$&'()*+,;=]/;
-  const invalidURL = [forwardTo, forwardConnectTo].find((url) => invalidURLCharsRE.test(url));
-  if (invalidURL) {
-    await vscode.window.showErrorMessage(`Invalid URL: ${invalidURL}`);
-    return;
-  }
-
-  if (Array.isArray(options.events)) {
-    const invalidEventCharsRE = /[^a-z_.]/;
-    const invalidEvent = options.events.find((e: string) => invalidEventCharsRE.test(e));
-    if (invalidEvent) {
-      await vscode.window.showErrorMessage(`Invalid chararacters found in event: ${invalidEvent}. For a list of all possible events, see https://stripe.com/docs/api/events/types.`);
+    const invalidURLCharsRE = /[^\w-.~:\/?#\[\]@!$&'()*+,;=]/;
+    const invalidURL = [forwardTo, forwardConnectTo].find((url) => invalidURLCharsRE.test(url));
+    if (invalidURL) {
+      await vscode.window.showErrorMessage(`Invalid URL: ${invalidURL}`);
       return;
     }
-  }
 
-  const forwardToFlag = forwardTo
-    ? ['--forward-to', forwardTo]
-    : [];
+    if (Array.isArray(options.events)) {
+      const invalidEventCharsRE = /[^a-z_.]/;
+      const invalidEvent = options.events.find((e: string) => invalidEventCharsRE.test(e));
+      if (invalidEvent) {
+        await vscode.window.showErrorMessage(`Invalid chararacters found in event: ${invalidEvent}. For a list of all possible events, see https://stripe.com/docs/api/events/types.`);
+        return;
+      }
+    }
+    const forwardToFlag = forwardTo
+      ? ['--forward-to', forwardTo]
+      : [];
 
-  const forwardConnectToFlag = forwardConnectTo
-    ? ['--forward-connect-to', forwardConnectTo]
-    : [];
+    const forwardConnectToFlag = forwardConnectTo
+      ? ['--forward-connect-to', forwardConnectTo]
+      : [];
 
-  const eventsFlag = Array.isArray(options.events) && options.events.length > 0
-    ? ['--events', options.events.join(',')]
-    : [];
+    const eventsFlag = Array.isArray(options.events) && options.events.length > 0
+      ? ['--events', options.events.join(',')]
+      : [];
 
-  terminal.execute(
-    'listen',
-    [
-      ...forwardToFlag,
-      ...forwardConnectToFlag,
-      ...eventsFlag
-    ]
-  );
+    this.terminal.execute('listen', [...forwardToFlag, ...forwardConnectToFlag, ...eventsFlag]);
+  };
+
+  openLogsStreaming = () => {
+    this.telemetry.sendEvent('openLogsStreaming');
+    this.terminal.execute('logs', ['tail']);
+  };
+
+  startLogin = () => {
+    this.telemetry.sendEvent('login');
+    this.terminal.execute('login');
+  };
+
+  openCLI = () => {
+    this.telemetry.sendEvent('openCLI');
+    const terminal = vscode.window.createTerminal('Stripe');
+    terminal.sendText('stripe ', false);
+    terminal.show();
+  };
+
+  openDashboardApikeys = () => {
+    this.telemetry.sendEvent('openDashboardApikeys');
+    vscode.env.openExternal(
+      vscode.Uri.parse('https://dashboard.stripe.com/test/apikeys')
+    );
+  };
+
+  openDashboardEvent = (stripeTreeItem: StripeTreeItem) => {
+    this.telemetry.sendEvent('openDashboardEvent');
+    vscode.env.openExternal(
+      vscode.Uri.parse(`https://dashboard.stripe.com/test/events/${stripeTreeItem.metadata.id}`)
+    );
+  };
+
+  openDashboardEvents = () => {
+    this.telemetry.sendEvent('openDashboardEvents');
+    vscode.env.openExternal(
+      vscode.Uri.parse('https://dashboard.stripe.com/test/events')
+    );
+  };
+
+  openDashboardLogs = () => {
+    this.telemetry.sendEvent('openDashboardLogs');
+    vscode.env.openExternal(
+      vscode.Uri.parse('https://dashboard.stripe.com/test/logs')
+    );
+  };
+
+  openDashboardWebhooks = () => {
+    this.telemetry.sendEvent('openDashboardWebhooks');
+    vscode.env.openExternal(
+      vscode.Uri.parse('https://dashboard.stripe.com/test/webhooks')
+    );
+  };
+
+  openEventDetails = (data: any) => {
+    this.telemetry.sendEvent('openEventDetails');
+    const {id, type} = data;
+    const filename = `${type} (${id})`;
+    const uri = vscode.Uri.parse(`stripeEvent:${filename}`);
+    vscode.window.withProgress({
+        location: vscode.ProgressLocation.Window,
+        title: 'Fetching Stripe event details',
+    }, async () => {
+      const doc = await vscode.workspace.openTextDocument(uri);
+      vscode.languages.setTextDocumentLanguage(doc, 'json');
+      vscode.window.showTextDocument(doc, {preview: false});
+    });
+  };
+
+  refreshEventsList = (stripeEventsViewProvider: StripeEventsDataProvider) => {
+    this.telemetry.sendEvent('refreshEventsList');
+    stripeEventsViewProvider.refresh();
+  };
+
+  openTriggerEvent = async (extensionContext: vscode.ExtensionContext) => {
+    this.telemetry.sendEvent('openTriggerEvent');
+    const events = this.buildTriggerEventsList(this.supportedEvents, extensionContext);
+    const eventName = await showQuickPickWithItems('Enter event name to trigger', events);
+    if (eventName) {
+      this.terminal.execute('trigger', [eventName]);
+      recordEvent(extensionContext, eventName);
+
+      // Trigger events refresh after 5s as we don't have a way to know when it has finished.
+      setTimeout(() => {
+        vscode.commands.executeCommand('stripe.refreshEventsList');
+      }, 5000);
+    }
+  };
+
+  buildTriggerEventsList = (
+    events: string[],
+    extensionContext: vscode.ExtensionContext
+  ): vscode.QuickPickItem[] => {
+    const historicEvents = getRecentEvents(extensionContext, 20);
+
+    // Get a unique list of events and take the first 5
+    const recentEvents = [
+      ...new Set<string>(historicEvents.filter((e: string) => events.includes(e))),
+    ].slice(0, 5);
+
+    const remainingEvents = events.filter((e) => !recentEvents.includes(e));
+
+    const recentItems = recentEvents.map((e) => {
+      return {
+        label: e,
+        description: 'recently triggered'
+      };
+    });
+
+    const remainingItems = remainingEvents.map((e) => {
+      return {
+        label: e,
+      };
+    });
+    return [...recentItems, ...remainingItems];
+  };
+
+  openReportIssue = () => {
+    this.telemetry.sendEvent('openReportIssue');
+    const {name, publisher} = getExtensionInfo();
+
+    vscode.commands.executeCommand('vscode.openIssueReporter', {
+      extensionId: `${publisher}.${name}`,
+    });
+  };
+
+  openWebhooksDebugConfigure = () => {
+    vscode.commands.executeCommand('workbench.action.debug.configure');
+  };
+
+  openDocs = () => {
+    this.telemetry.sendEvent('openDocs');
+    vscode.env.openExternal(
+      vscode.Uri.parse('https://stripe.com/docs/stripe-vscode')
+    );
+  };
+
+  openSurvey = () => {
+    this.telemetry.sendEvent('openSurvey');
+    const extensionInfo = getExtensionInfo();
+
+    const query = querystring.stringify({
+      platform: encodeURIComponent(osName()),
+      vscodeVersion: encodeURIComponent(vscode.version),
+      extensionVersion: encodeURIComponent(extensionInfo.version),
+      machineId: encodeURIComponent(vscode.env.machineId),
+    });
+
+    const url = `https://stri.pe/vscode-feedback?${query}`;
+    vscode.env.openExternal(vscode.Uri.parse(url));
+  };
+
+  openTelemetryInfo = () => {
+    vscode.env.openExternal(
+      vscode.Uri.parse('https://code.visualstudio.com/docs/getstarted/telemetry')
+    );
+  };
+
+  resendEvent = (stripeTreeItem: StripeTreeItem) => {
+    this.telemetry.sendEvent('resendEvent');
+    this.terminal.execute('events', ['resend', stripeTreeItem.metadata.id]);
+  };
 }
-
-export function openLogsStreaming() {
-  telemetry.sendEvent('openLogsStreaming');
-  terminal.execute('logs', ['tail']);
-}
-
-export function startLogin() {
-  telemetry.sendEvent('login');
-  terminal.execute('login');
-}
-
-export function openCLI() {
-  telemetry.sendEvent('openCLI');
-  const terminal = vscode.window.createTerminal('Stripe');
-  terminal.sendText('stripe ', false);
-  terminal.show();
-}
-
-export function openDashboardApikeys() {
-  telemetry.sendEvent('openDashboardApikeys');
-  vscode.env.openExternal(
-    vscode.Uri.parse('https://dashboard.stripe.com/test/apikeys')
-  );
-}
-
-export function openDashboardEvent(stripeTreeItem: StripeTreeItem) {
-  telemetry.sendEvent('openDashboardEvent');
-  vscode.env.openExternal(
-    vscode.Uri.parse(`https://dashboard.stripe.com/test/events/${stripeTreeItem.metadata.id}`)
-  );
-}
-
-export function openDashboardEvents() {
-  telemetry.sendEvent('openDashboardEvents');
-  vscode.env.openExternal(
-    vscode.Uri.parse('https://dashboard.stripe.com/test/events')
-  );
-}
-export function openDashboardLogs() {
-  telemetry.sendEvent('openDashboardLogs');
-  vscode.env.openExternal(
-    vscode.Uri.parse('https://dashboard.stripe.com/test/logs')
-  );
-}
-
-export function openDashboardWebhooks() {
-  telemetry.sendEvent('openDashboardWebhooks');
-  vscode.env.openExternal(
-    vscode.Uri.parse('https://dashboard.stripe.com/test/webhooks')
-  );
-}
-
-export function openEventDetails(data: any) {
-  telemetry.sendEvent('openEventDetails');
-  const {id, type} = data;
-  const filename = `${type} (${id})`;
-  const uri = vscode.Uri.parse(`stripeEvent:${filename}`);
-  vscode.window.withProgress({
-      location: vscode.ProgressLocation.Window,
-      title: 'Fetching Stripe event details',
-  }, async () => {
-    const doc = await vscode.workspace.openTextDocument(uri);
-    vscode.languages.setTextDocumentLanguage(doc, 'json');
-    vscode.window.showTextDocument(doc, {preview: false});
-  });
-}
-
-export function refreshEventsList(
-  stripeEventsViewProvider: StripeEventsDataProvider
-) {
-  telemetry.sendEvent('refreshEventsList');
-  stripeEventsViewProvider.refresh();
-}
-
-export async function openTriggerEvent(extensionContext: vscode.ExtensionContext) {
-  telemetry.sendEvent('openTriggerEvent');
-  const events = buildTriggerEventsList(supportedEvents, extensionContext);
-  const eventName = await showQuickPickWithItems('Enter event name to trigger', events);
-  if (eventName) {
-    terminal.execute('trigger', [eventName]);
-    recordEvent(extensionContext, eventName);
-
-    // Trigger events refresh after 5s as we don't have a way to know when it has finished.
-    setTimeout(() => {
-      vscode.commands.executeCommand('stripe.refreshEventsList');
-    }, 5000);
-  }
-}
-
-export function buildTriggerEventsList(events: string[], extensionContext: vscode.ExtensionContext):
-    vscode.QuickPickItem[] {
-  const historicEvents = getRecentEvents(extensionContext, 20);
-
-  // Get a unique list of events and take the first 5
-  const recentEvents =
-    [...new Set<string>(historicEvents.filter((e: string) => events.includes(e)))].slice(0,5);
-
-  const remainingEvents = events.filter((e) => !recentEvents.includes(e));
-
-  const recentItems = recentEvents.map((e) => {
-    return {
-      label: e,
-      description: 'recently triggered'
-    };
-  });
-
-  const remainingItems = remainingEvents.map((e) => {
-    return {
-      label: e,
-    };
-  });
-  return [...recentItems, ...remainingItems];
-}
-
-export function openReportIssue() {
-  telemetry.sendEvent('openReportIssue');
-  const {name, publisher} = getExtensionInfo();
-
-  vscode.commands.executeCommand('vscode.openIssueReporter', {
-    extensionId: `${publisher}.${name}`,
-  });
-}
-
-export function openWebhooksDebugConfigure() {
-  vscode.commands.executeCommand('workbench.action.debug.configure');
-}
-
-export function openDocs() {
-  telemetry.sendEvent('openDocs');
-  vscode.env.openExternal(
-    vscode.Uri.parse('https://stripe.com/docs/stripe-vscode')
-  );
-}
-
-export function openSurvey() {
-  telemetry.sendEvent('openSurvey');
-  const extensionInfo = getExtensionInfo();
-
-  const query = querystring.stringify({
-    platform: encodeURIComponent(osName()),
-    vscodeVersion: encodeURIComponent(vscode.version),
-    extensionVersion: encodeURIComponent(extensionInfo.version),
-    machineId: encodeURIComponent(vscode.env.machineId),
-  });
-
-  const url = `https://stri.pe/vscode-feedback?${query}`;
-  vscode.env.openExternal(vscode.Uri.parse(url));
-}
-
-export function openTelemetryInfo() {
-  vscode.env.openExternal(
-    vscode.Uri.parse('https://code.visualstudio.com/docs/getstarted/telemetry')
-  );
-}
-
-export function resendEvent(stripeTreeItem: StripeTreeItem) {
-  telemetry.sendEvent('resendEvent');
-  terminal.execute('events', ['resend', stripeTreeItem.metadata.id]);
-}
-
-const supportedEvents: string[] = [
-  'balance.available',
-  'charge.captured',
-  'charge.dispute.created',
-  'charge.failed',
-  'charge.refunded',
-  'charge.succeeded',
-  'checkout.session.completed',
-  'customer.created',
-  'customer.deleted',
-  'customer.source.created',
-  'customer.source.updated',
-  'customer.subscription.created',
-  'customer.subscription.deleted',
-  'customer.subscription.updated',
-  'customer.updated',
-  'invoice.created',
-  'invoice.finalized',
-  'invoice.payment_failed',
-  'invoice.payment_succeeded',
-  'invoice.updated',
-  'issuing_authorization.request',
-  'issuing_card.created',
-  'issuing_cardholder.created',
-  'payment_intent.amount_capturable_updated',
-  'payment_intent.canceled',
-  'payment_intent.created',
-  'payment_intent.payment_failed',
-  'payment_intent.succeeded',
-  'payment_method.attached',
-  'plan.created',
-  'plan.deleted',
-  'plan.updated',
-  'product.created',
-  'product.deleted',
-  'product.updated',
-  'setup_intent.canceled',
-  'setup_intent.created',
-  'setup_intent.setup_failed',
-  'setup_intent.succeeded',
-  'subscription_schedule.canceled',
-  'subscription_schedule.created',
-  'subscription_schedule.released',
-  'subscription_schedule.updated',
-];

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,25 +1,6 @@
 import {ExtensionContext, commands, debug, window, workspace} from 'vscode';
 import {ServerOptions, TransportKind} from 'vscode-languageclient';
-import {
-  openCLI,
-  openDashboardApikeys,
-  openDashboardEvent,
-  openDashboardEvents,
-  openDashboardLogs,
-  openDashboardWebhooks,
-  openDocs,
-  openEventDetails,
-  openLogsStreaming,
-  openReportIssue,
-  openSurvey,
-  openTelemetryInfo,
-  openTriggerEvent,
-  openWebhooksDebugConfigure,
-  openWebhooksListen,
-  refreshEventsList,
-  resendEvent,
-  startLogin,
-} from './commands';
+import {Commands} from './commands';
 import {GATelemetry} from './telemetry';
 import {Resource} from './resources';
 import {StripeClient} from './stripeClient';
@@ -31,6 +12,7 @@ import {StripeHelpViewDataProvider} from './stripeHelpView';
 import {StripeLanguageClient} from './stripeLanguageServer/client';
 import {StripeLinter} from './stripeLinter';
 import {StripeLogsDataProvider} from './stripeLogsView';
+import {StripeTerminal} from './stripeTerminal';
 import {SurveyPrompt} from './surveyPrompt';
 import {TelemetryPrompt} from './telemetryPrompt';
 import path from 'path';
@@ -50,6 +32,8 @@ export function activate(this: any, context: ExtensionContext) {
   new SurveyPrompt(context).activate();
 
   Resource.initialize(context);
+
+  const stripeCommands = new Commands(telemetry, new StripeTerminal());
 
   // Activity bar view
   window.createTreeView('stripeDashboardView', {
@@ -108,53 +92,53 @@ export function activate(this: any, context: ExtensionContext) {
 
   // Commands
   const subscriptions = context.subscriptions;
-  const boundRefreshEventsList = refreshEventsList.bind(
+  const boundRefreshEventsList = stripeCommands.refreshEventsList.bind(
     this,
     stripeEventsViewProvider
   );
 
   context.subscriptions.push(
-    commands.registerCommand('stripe.openCLI', openCLI)
+    commands.registerCommand('stripe.openCLI', stripeCommands.openCLI)
   );
 
   context.subscriptions.push(
-    commands.registerCommand('stripe.login', startLogin)
+    commands.registerCommand('stripe.login', stripeCommands.startLogin)
   );
 
   subscriptions.push(
-    commands.registerCommand('stripe.openWebhooksListen', openWebhooksListen)
+    commands.registerCommand('stripe.openWebhooksListen', stripeCommands.openWebhooksListen)
   );
 
   subscriptions.push(
-    commands.registerCommand('stripe.openLogsStreaming', openLogsStreaming)
+    commands.registerCommand('stripe.openLogsStreaming', stripeCommands.openLogsStreaming)
   );
 
   subscriptions.push(
-    commands.registerCommand('stripe.openDashboardEvents', openDashboardEvents)
+    commands.registerCommand('stripe.openDashboardEvents', stripeCommands.openDashboardEvents)
   );
 
   subscriptions.push(
-    commands.registerCommand('stripe.openDashboardLogs', openDashboardLogs)
+    commands.registerCommand('stripe.openDashboardLogs', stripeCommands.openDashboardLogs)
   );
 
   subscriptions.push(
     commands.registerCommand(
       'stripe.openEventDetails',
-      openEventDetails
+      stripeCommands.openEventDetails
     )
   );
 
   subscriptions.push(
     commands.registerCommand(
       'stripe.openDashboardApikeys',
-      openDashboardApikeys
+      stripeCommands.openDashboardApikeys
     )
   );
 
   subscriptions.push(
     commands.registerCommand(
       'stripe.openDashboardWebhooks',
-      openDashboardWebhooks
+      stripeCommands.openDashboardWebhooks
     )
   );
 
@@ -163,33 +147,33 @@ export function activate(this: any, context: ExtensionContext) {
   );
 
   subscriptions.push(
-    commands.registerCommand('stripe.openTriggerEvent', () => openTriggerEvent(context))
+    commands.registerCommand('stripe.openTriggerEvent', () => stripeCommands.openTriggerEvent(context))
   );
 
-  subscriptions.push(commands.registerCommand('stripe.openSurvey', openSurvey));
+  subscriptions.push(commands.registerCommand('stripe.openSurvey', stripeCommands.openSurvey));
 
   subscriptions.push(
-    commands.registerCommand('stripe.openTelemetryInfo', openTelemetryInfo)
+    commands.registerCommand('stripe.openTelemetryInfo', stripeCommands.openTelemetryInfo)
   );
 
   subscriptions.push(
-    commands.registerCommand('stripe.openReportIssue', openReportIssue)
+    commands.registerCommand('stripe.openReportIssue', stripeCommands.openReportIssue)
   );
 
-  subscriptions.push(commands.registerCommand('stripe.openDocs', openDocs));
+  subscriptions.push(commands.registerCommand('stripe.openDocs', stripeCommands.openDocs));
   subscriptions.push(
     commands.registerCommand(
       'stripe.openWebhooksDebugConfigure',
-      openWebhooksDebugConfigure
+      stripeCommands.openWebhooksDebugConfigure
     )
   );
 
   subscriptions.push(
-    commands.registerCommand('stripe.resendEvent', resendEvent)
+    commands.registerCommand('stripe.resendEvent', stripeCommands.resendEvent)
   );
 
   subscriptions.push(
-    commands.registerCommand('stripe.openDashboardEvent', openDashboardEvent)
+    commands.registerCommand('stripe.openDashboardEvent', stripeCommands.openDashboardEvent)
   );
 }
 

--- a/src/test/suite/commands.test.ts
+++ b/src/test/suite/commands.test.ts
@@ -1,11 +1,20 @@
 import * as assert from 'assert';
-import * as commands from '../../commands';
 import * as sinon from 'sinon';
 import * as stripeState from '../../stripeWorkspaceState';
+import * as vscode from 'vscode';
+
+import {Commands} from '../../commands';
+import {NoOpTelemetry} from '../../telemetry';
 import {mocks} from '../mocks/vscode';
 
 suite('commands', () => {
   let sandbox: sinon.SinonSandbox;
+  const terminal = <any>{
+    execute: (command: any, args: Array<string>) => {},
+  };
+
+  const telemetry = new NoOpTelemetry();
+
   setup(() => {
     sandbox = sinon.createSandbox();
   });
@@ -14,11 +23,31 @@ suite('commands', () => {
     sandbox.restore();
   });
 
-  suite('buildTriggerEventsList',() => {
+  suite('openTriggerEvent', () => {
+    test('executes and records event', async () => {
+      const extensionContext = {...mocks.extensionContextMock};
+      const terminalSpy = sandbox.spy(terminal, 'execute');
+      const telemetrySpy = sandbox.spy(telemetry, 'sendEvent');
+
+      const supportedEvents = ['a'];
+
+      const commands = new Commands(telemetry, terminal, supportedEvents);
+      commands.openTriggerEvent(extensionContext);
+      // Pick the first item on the list.
+      await vscode.commands.executeCommand('workbench.action.acceptSelectedQuickOpenItem');
+      const eventsInState = stripeState.getRecentEvents(extensionContext);
+
+      assert.deepStrictEqual(terminalSpy.args[0], ['trigger', ['a']]);
+      assert.deepStrictEqual(telemetrySpy.args[0], ['openTriggerEvent']);
+      assert.deepStrictEqual(eventsInState, ['a']);
+    });
+  });
+
+  suite('buildTriggerEventsList', () => {
     test('returns all original events when no recent events', () => {
       const extensionContext = {...mocks.extensionContextMock};
       const getEventsStub = sandbox.stub(stripeState, 'getRecentEvents').returns([]);
-
+      const commands = new Commands(telemetry, terminal);
       const supportedEvents = ['a', 'b', 'c', 'd', 'e'];
       const events = commands.buildTriggerEventsList(supportedEvents, extensionContext);
 
@@ -30,6 +59,7 @@ suite('commands', () => {
     test('returns recent events on top', () => {
       const extensionContext = {...mocks.extensionContextMock};
       const getEventsStub = sandbox.stub(stripeState, 'getRecentEvents').returns(['c']);
+      const commands = new Commands(telemetry, terminal);
 
       const supportedEvents = ['a', 'b', 'c', 'd', 'e'];
       const events = commands.buildTriggerEventsList(supportedEvents, extensionContext);
@@ -42,7 +72,10 @@ suite('commands', () => {
 
     test('does not include events that are not supported', () => {
       const extensionContext = {...mocks.extensionContextMock};
-      const getEventsStub = sandbox.stub(stripeState, 'getRecentEvents').returns(['c', 'unsupported']);
+      const getEventsStub = sandbox
+        .stub(stripeState, 'getRecentEvents')
+        .returns(['c', 'unsupported']);
+      const commands = new Commands(telemetry, terminal);
 
       const supportedEvents = ['a', 'b', 'c', 'd', 'e'];
       const events = commands.buildTriggerEventsList(supportedEvents, extensionContext);
@@ -50,7 +83,6 @@ suite('commands', () => {
       const labels = events.map((x) => x.label);
       assert.deepStrictEqual(labels, ['c', 'a', 'b', 'd', 'e']);
       assert.strictEqual(events[0].description, 'recently triggered');
-
     });
   });
 });


### PR DESCRIPTION
This commit converts the Commands module into a class so that we can inject instances of telemetry and stripeTerminal. This has the benefit of making unit testing this class a bit easier, and of course allowing the caller to control which instance of telemetry to use under different circumstances. 


### Testing
I manually tested all the commands in debug mode. It should be easier to add more unit tests from now on, I started with a few for the commands class for now. 