### PR TITLE
Ignore the user's VS Code terminals that are running `stripe`

### DIFF
--- a/src/stripeTerminal.ts
+++ b/src/stripeTerminal.ts
@@ -90,29 +90,10 @@ export class StripeTerminal {
     return null;
   }
 
-  private async getUsersStripeTerminal(
-    allRunningProcesses: psList.ProcessDescriptor[]
-  ): Promise<vscode.Terminal | undefined> {
-    const usersTerminals = vscode.window.terminals.filter((t) => !this.terminals.includes(t));
-    const usersStripeTerminal = await findAsync(usersTerminals, async (t) => {
-      const runningCommand = await this.getRunningCommand(t, allRunningProcesses);
-      return !!runningCommand && this.isCommandLongRunning(runningCommand);
-    });
-    return usersStripeTerminal;
-  }
-
   private async terminalForCommand(
     command: string,
     allRunningProcesses: psList.ProcessDescriptor[],
   ): Promise<vscode.Terminal> {
-    // If the user had manually created a terminal and ran `stripe listen` or `stripe logs tail`,
-    // we would want to know about it so that we can reuse that terminal or spawn new split
-    // terminals off of it. This gives a better experience than ignoring that terminal.
-    const usersStripeTerminal = await this.getUsersStripeTerminal(allRunningProcesses);
-    if (this.terminals.length === 0 && usersStripeTerminal) {
-      this.terminals.push(usersStripeTerminal);
-    }
-
     // If the command is a long-running one, and it's already running in a VS Code terminal,
     // we restart it in the same terminal. This does not occur on Windows due to OS limitations.
     if (this.isCommandLongRunning(command)) {

--- a/src/test/suite/stripeTerminal.test.ts
+++ b/src/test/suite/stripeTerminal.test.ts
@@ -37,47 +37,4 @@ suite('stripeTerminal', function() {
     assert.strictEqual(createTerminalStub.callCount, 1);
     assert.strictEqual(sendTextStub.getCalls()[0].args[0], 'stripe listen --foward-to localhost');
   });
-
-  test('sends long-running command to a user-created Stripe terminal', async () => {
-    // The user created a terminal and ran `stripe listen` manually.
-    const sendTextStub = sandbox.stub(terminalStub, 'sendText');
-    sandbox.stub(vscode.window, 'terminals').value([terminalStub]);
-    sandbox.stub(StripeTerminal.prototype, <any>'getRunningCommand').returns('stripe listen');
-
-    const createTerminalStub = sandbox.stub(vscode.window, 'createTerminal');
-
-    // The user invokes "Start webhooks listening" from the extension.
-    const stripeTerminal = new StripeTerminal();
-    await stripeTerminal.execute('listen');
-
-    assert.strictEqual(createTerminalStub.callCount, 0);
-    assert.strictEqual(sendTextStub.getCalls()[0].args[0], 'stripe listen');
-  });
-
-  test('splits off of a user-created Stripe terminal', async () => {
-    // The user created a terminal and ran `stripe listen` manually.
-    const usersSendTextStub = sandbox.stub(terminalStub, 'sendText');
-    sandbox.stub(vscode.window, 'terminals').value([terminalStub]);
-    sandbox.stub(StripeTerminal.prototype, <any>'getRunningCommand').returns('stripe listen');
-
-    const newTerminalStub = {
-      ...terminalStub,
-      sendText: (text: string, addNewLine?: boolean) => {},
-    };
-    const createNewSplitTerminalStub = sandbox
-      .stub(StripeTerminal.prototype, <any>'createNewSplitTerminal')
-      .returns(newTerminalStub);
-    const newSendTextStub = sandbox.stub(newTerminalStub, 'sendText');
-
-    const createTerminalStub = sandbox.stub(vscode.window, 'createTerminal');
-
-    // The user invokes "Start API logs streaming" from the extension.
-    const stripeTerminal = new StripeTerminal();
-    await stripeTerminal.execute('logs', ['tail']);
-
-    assert.strictEqual(createTerminalStub.callCount, 0);
-    assert.strictEqual(usersSendTextStub.callCount, 0);
-    assert.strictEqual(createNewSplitTerminalStub.callCount, 1);
-    assert.strictEqual(newSendTextStub.getCalls()[0].args[0], 'stripe logs tail');
-  });
 });


### PR DESCRIPTION
### Notify
cc @stripe/developer-products @tjfontaine-stripe @auchenberg-stripe 

### Summary
Remove detecting if the user has run `stripe` commands in their vscode terminals manually. This undoes https://github.com/stripe/vscode-stripe/issues/55.

### Motivation
After discussions about how to handle detecting if a user is running Stripe CLI commands manually, we determined that this is a difficult problem that can easily lead to issues on the user's system:
- A user's `stripe` command may not be the CLI. We have no idea what killing their `stripe` process would do.
- Our solution to this may not be portable, potentially requiring a code path for each OS. We would need an extra dependency just to handle this if we wanted to avoid that.

As it currently stands, the behavior we wanted to land is not necessarily part of the core functionality, and there is risk of causing problems on the user's system.

### Testing
- Remove tests that involve the user's stripe terminals.
- Manually verify the behavior on the extension development host.
  - Verified that the extension will always create a new terminal for running commands
  - Verified that the extension will ignore user's `stripe logs tail` and `stripe listen` commands that they had invoked manually