### PR TITLE
Updating StripeLinter to take in an instance of telemetry and adding unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ Contributions and feedback to the project are welcome, so please open issues for
 1. Run the `Run Extension` target in the Debug View or simply press `F5` This will:
    - Start a task `npm: watch` to compile the code
    - Run the extension in a new VS Code window
+1. Disable the Stripe Extension for this workspace.
+   - Right click "Stripe" from the Extensions markeyplace
+   - Click Disable (Workspace)
 
 ## License
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -69,7 +69,7 @@ export function activate(this: any, context: ExtensionContext) {
   );
 
   // Stripe Linter
-  const stripeLinter = new StripeLinter();
+  const stripeLinter = new StripeLinter(telemetry);
   stripeLinter.activate();
 
   // Language Server for hover matching of Stripe methods

--- a/src/test/suite/stripeLinter.test.ts
+++ b/src/test/suite/stripeLinter.test.ts
@@ -1,0 +1,74 @@
+
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import * as stripeLinter from '../../stripeLinter';
+import * as vscode from 'vscode';
+import {NoOpTelemetry} from '../../telemetry';
+
+suite('StripeLinter', () => {
+  let sandbox: sinon.SinonSandbox;
+  const telemetry = new NoOpTelemetry();
+
+  setup(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  teardown(() => {
+    sandbox.restore();
+  });
+
+  suite('lookForHardCodedAPIKeys', () => {
+
+    test('Editor content is not searched when shoudSearchFile returns false', async() => {
+      const options = {content: 'I have content with critical data : sk_live_1234'};
+      await vscode.workspace.openTextDocument(options)
+        .then((doc) => vscode.window.showTextDocument(doc, {preview: false}));
+
+      const shouldSearchStub = sandbox.stub(stripeLinter, 'shouldSearchFile').returns(false);
+      const telemetrySpy = sandbox.spy(telemetry, 'sendEvent');
+
+      const linter = new stripeLinter.StripeLinter(telemetry);
+      linter.activate();
+
+      const diagnostics = vscode.languages.getDiagnostics();
+      assert.strictEqual(shouldSearchStub.calledOnce, true);
+      assert.strictEqual(telemetrySpy.callCount, 0);
+      assert.strictEqual(diagnostics.length, 0);
+    });
+
+    test('Diagnostics are pushed when linter finds offenses', async() => {
+      const options = {content: 'I have content with critical data : sk_live_1234'};
+      const document = await vscode.workspace.openTextDocument(options);
+      await vscode.window.showTextDocument(document, {preview: false});
+
+      const shouldSearchStub = sandbox.stub(stripeLinter, 'shouldSearchFile').returns(true);
+      const telemetrySpy = sandbox.spy(telemetry, 'sendEvent');
+
+      const linter = new stripeLinter.StripeLinter(telemetry);
+      linter.activate();
+      const diagnostics: vscode.Diagnostic[] = vscode.languages.getDiagnostics(document.uri);
+
+      assert.strictEqual(shouldSearchStub.calledOnce, true);
+      assert.strictEqual(telemetrySpy.calledOnce, true);
+      assert.deepStrictEqual(telemetrySpy.args[0], ['diagnostics.show', vscode.DiagnosticSeverity.Error]);
+      assert.strictEqual(diagnostics.length, 1);
+    });
+
+    test('No diagnostics are pushed when file is clean', async() => {
+      const options = {content: 'I am a good file'};
+      const document = await vscode.workspace.openTextDocument(options);
+      await vscode.window.showTextDocument(document, {preview: false});
+
+      const shouldSearchStub = sandbox.stub(stripeLinter, 'shouldSearchFile').returns(true);
+      const telemetrySpy = sandbox.spy(telemetry, 'sendEvent');
+
+      const linter = new stripeLinter.StripeLinter(telemetry);
+      linter.activate();
+      const diagnostics: vscode.Diagnostic[] = vscode.languages.getDiagnostics(document.uri);
+
+      assert.strictEqual(shouldSearchStub.calledOnce, true);
+      assert.strictEqual(telemetrySpy.callCount, 0);
+      assert.strictEqual(diagnostics.length, 0);
+    });
+  });
+});


### PR DESCRIPTION
Note about the ReadME Update: If you have the Stripe extension turned on for all workspaces (which I think is the default), it runs the linter on this repo which will be unhappy about the test I just added.