### PR TITLE
Prompt user to install CLI or show error message on configuration change

### DIFF
--- a/src/test/suite/stripeClient.test.ts
+++ b/src/test/suite/stripeClient.test.ts
@@ -62,6 +62,22 @@ suite('stripeClient', () => {
           });
         });
       });
+
+      test('prompts install when CLI is not installed', async () => {
+        sandbox.stub(fs.promises, 'stat').returns(Promise.resolve({isFile: () => false}));
+        const showErrorMessageSpy = sandbox.stub(vscode.window, 'showErrorMessage');
+        const stripeClient = new StripeClient(new NoOpTelemetry());
+        const isInstalled = await stripeClient.detectInstalled();
+        assert.strictEqual(isInstalled, false);
+        assert.deepStrictEqual(
+          showErrorMessageSpy.args[0],
+          [
+            'Welcome! Stripe is using the Stripe CLI behind the scenes, and requires it to be installed on your machine',
+            {},
+            'Read instructions on how to install Stripe CLI',
+          ]
+        );
+      });
     });
 
     suite('with custom CLI install path', () => {
@@ -109,6 +125,18 @@ suite('stripeClient', () => {
             assert.strictEqual(stripeClient.cliPath, null);
           });
         });
+      });
+
+      test('shows error when CLI is not at that path', async () => {
+        statStub.returns(Promise.resolve({isFile: () => false}));
+        const showErrorMessageSpy = sandbox.stub(vscode.window, 'showErrorMessage');
+        const stripeClient = new StripeClient(new NoOpTelemetry());
+        const isInstalled = await stripeClient.detectInstalled();
+        assert.strictEqual(isInstalled, false);
+        assert.deepStrictEqual(
+          showErrorMessageSpy.args[0],
+          ["You set a custom installation path for the Stripe CLI, but we couldn't find the executable in '/foo/bar/baz'", 'Ok'],
+        );
       });
     });
   });


### PR DESCRIPTION
### Notify
cc @stripe/developer-products 

### Summary
Listen for changes to `stripe` settings. If the user changes their `stripe.cliInstallPath`, we re-detect if they have the CLI installed there and prompt accordingly if they don't.

This required a little bit of refactoring, including changing the side effects that `detectInstalled()` produces.

Examples:

![Screen Shot 2021-01-27 at 4 29 59 PM](https://user-images.githubusercontent.com/71457708/106073327-b021f400-60be-11eb-92ae-b4613ca8e34b.png)
The `stripe.cliInstallPath` setting is not specified and the CLI isn't installed; prompt install.

![Screen Shot 2021-01-27 at 4 30 12 PM](https://user-images.githubusercontent.com/71457708/106073340-b31ce480-60be-11eb-8e15-1a6736b05a77.png)
The `stripe.cliInstallPath` setting is specified, but the CLI isn't installed there; show error.

![Screen Shot 2021-01-27 at 4 30 32 PM](https://user-images.githubusercontent.com/71457708/106073349-b617d500-60be-11eb-8450-4068e820bfaf.png)
The `stripe.cliInstallPath` setting is specified and the CLI is there (I moved it from `stripe` -> `stripe2`); no error.

### Motivation
After #135, we have started respecting the user's `stripe.cliInstallPath` setting. This would work as intended on extension activation, but not if a user changed that setting and didn't reload the window.

### Testing
- Added test to verify that we prompt for installation if `stripe.cliInstallPath` isn't specified and the CLI isn't installed at the default path
- Added test to verify an error message is shown if `stripe.cliInstallPath` is specified and the CLI isn't installed there
- Manually verified; see screenshots
