### PR TITLE
Disabling telemetry during in extension development mode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,7 +15,10 @@
 			"outFiles": [
 				"${workspaceFolder}/out/**/*.js"
 			],
-			"preLaunchTask": "npm: watch"
+			"preLaunchTask": "npm: watch",
+			"env": {
+				"IS_DEVELOPEMENT_MODE": "true"
+			}
 		}
 	]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,7 +17,7 @@
 			],
 			"preLaunchTask": "npm: watch",
 			"env": {
-				"IS_DEVELOPEMENT_MODE": "true"
+				"EXTENSION_MODE": "development"
 			}
 		}
 	]

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Contributions and feedback to the project are welcome, so please open issues for
    - Start a task `npm: watch` to compile the code
    - Run the extension in a new VS Code window
 1. Disable the Stripe Extension for this workspace.
-   - Right click "Stripe" from the Extensions markeyplace
+   - Right click "Stripe" from the Extensions marketplace
    - Click Disable (Workspace)
 
 ## License

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -180,12 +180,12 @@ export function activate(this: any, context: ExtensionContext) {
 export function deactivate() {}
 
 /**
- * Checks for the explicit setting of the IS_DEVELOPEMENT_MODE and
+ * Checks for the explicit setting of the EXTENSION_MODE and
  * Implcitly checks by using the magic session string. This session value is used whenever an extension
  * is running on a development host. https://github.com/microsoft/vscode/issues/10272
  */
 function getTelemetry() {
-  if (process.env.IS_DEVELOPEMENT_MODE === 'true' || env.sessionId === 'someValue.sessionId') {
+  if (process.env.EXTENSION_MODE === 'development' || env.sessionId === 'someValue.sessionId') {
     console.log('Extension is running in development mode. Using local telemetry instance');
     return new LocalTelemetry();
   } else {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,7 @@
-import {ExtensionContext, commands, debug, window, workspace} from 'vscode';
+import {ExtensionContext, commands, debug, env, window, workspace} from 'vscode';
+import {GATelemetry, LocalTelemetry} from './telemetry';
 import {ServerOptions, TransportKind} from 'vscode-languageclient';
 import {Commands} from './commands';
-import {GATelemetry} from './telemetry';
 import {Resource} from './resources';
 import {StripeClient} from './stripeClient';
 import {StripeDashboardViewDataProvider} from './stripeDashboardView';
@@ -22,7 +22,7 @@ export function activate(this: any, context: ExtensionContext) {
   new TelemetryPrompt(context).activate();
 
   // Telemetry
-  const telemetry = GATelemetry.getInstance();
+  const telemetry = getTelemetry();
   telemetry.sendEvent('activate');
 
   // Stripe CLi client
@@ -178,3 +178,18 @@ export function activate(this: any, context: ExtensionContext) {
 }
 
 export function deactivate() {}
+
+/**
+ * Checks for the explicit setting of the IS_DEVELOPEMENT_MODE and
+ * Implcitly checks by using the magic session string. This session value is used whenever an extension
+ * is running on a development host. https://github.com/microsoft/vscode/issues/10272
+ */
+function getTelemetry() {
+  if (process.env.IS_DEVELOPEMENT_MODE === 'true' || env.sessionId === 'someValue.sessionId') {
+    console.log('Extension is running in development mode. Using local telemetry instance');
+    return new LocalTelemetry();
+  } else {
+    return GATelemetry.getInstance();
+  }
+
+}

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -23,11 +23,16 @@ async function main() {
       '--disable-extensions'
     ];
 
+    const extensionTestsEnv = {
+      IS_DEVELOPEMENT_MODE: 'development'
+    };
+
     // Download VS Code, unzip it and run the integration test
     await runTests({
       extensionDevelopmentPath,
       extensionTestsPath,
       launchArgs,
+      extensionTestsEnv
     });
   } catch (err) {
     console.log(err);

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -24,7 +24,7 @@ async function main() {
     ];
 
     const extensionTestsEnv = {
-      IS_DEVELOPEMENT_MODE: 'development'
+      EXTENSION_MODE: 'development'
     };
 
     // Download VS Code, unzip it and run the integration test


### PR DESCRIPTION
Replaced with a local version of telemetry that emits logs to the console:
![Screen Shot 2021-01-27 at 6 23 36 PM](https://user-images.githubusercontent.com/75757829/106081579-faf73800-60cd-11eb-8d6b-9df19366dade.png)

I know the possibility of setting NODE_ENV = 'development' was mentioned but I thought it would be safer to explicitly set our own variable to use. NODE_ENV looks like a common env_var and I worry that it could be set as 'development' just because our users are using our extension while they are developing. The sessionID check is a backup in case we forget to add the special flag for whatever reason. Though, please do let know me know if there is a more robust way to do this. 