### PR TITLE
Fixing issue with SurveyPrompt not persisting data in extension context

### DIFF
--- a/src/surveyPrompt.ts
+++ b/src/surveyPrompt.ts
@@ -54,7 +54,7 @@ export class SurveyPrompt {
     return true;
   }
 
-  public async showSurvey() {
+  showSurvey = async() => {
     const prompts = ['Take survey', 'Maybe later', "Don't Show Again"];
 
     const selection = await vscode.window.showInformationMessage(
@@ -74,5 +74,5 @@ export class SurveyPrompt {
     } else if (selection === "Don't Show Again") {
       this.storage.update(StorageKeys.doNotShowAgain, true);
     }
-  }
+  };
 }


### PR DESCRIPTION
This should address https://github.com/stripe/vscode-stripe/issues/143

Changing this to an arrow function means `this` will always be in context of our SurveyPrompt class. Before, it would be in context of whoever called this showSurvey() function which is from within the `setTimeout` function, I believe. 

## Testing
1. I removed the timeout and random assignment of the survey to force the survey to show up.
2. Without this change, the we silently fail on this line `this.storage.update(StorageKeys.lastSurveyDate, currentEpoch);`
3. With this change, we persist the data. Clicking "Take survey" and then re-starting the run a second time results in no survey being prompted.
