### PR TITLE
Run commands in vscode terminal with full path to CLI

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -33,7 +33,9 @@ export function activate(this: any, context: ExtensionContext) {
 
   Resource.initialize(context);
 
-  const stripeCommands = new Commands(telemetry, new StripeTerminal());
+  const stripeTerminal = new StripeTerminal(stripeClient);
+
+  const stripeCommands = new Commands(telemetry, stripeTerminal);
 
   // Activity bar view
   window.createTreeView('stripeDashboardView', {

--- a/src/stripeClient.ts
+++ b/src/stripeClient.ts
@@ -10,7 +10,7 @@ const fs = require('fs');
 
 export class StripeClient {
   telemetry: Telemetry;
-  cliPath: string | null;
+  private cliPath: string | null;
 
   constructor(telemetry:Telemetry) {
     this.telemetry = telemetry;
@@ -98,7 +98,25 @@ export class StripeClient {
     }
   }
 
-  async detectInstalled() {
+  getEvents() {
+    const events = this.execute('events list');
+    return events;
+  }
+
+  getResourceById(id: string) {
+    const resource = this.execute(`get ${id}`);
+    return resource;
+  }
+
+  async getCLIPath(): Promise<string | null> {
+    const isInstalled = await this.detectInstalled();
+    if (!isInstalled) {
+      return null;
+    }
+    return this.cliPath;
+  }
+
+  private async detectInstalled() {
     const defaultInstallPath = (() => {
       const osType: OSType = getOSType();
       switch (osType) {
@@ -138,16 +156,6 @@ export class StripeClient {
     this.cliPath = null;
     this.telemetry.sendEvent('cli.notInstalled');
     return false;
-  }
-
-  getEvents() {
-    const events = this.execute('events list');
-    return events;
-  }
-
-  getResourceById(id: string) {
-    const resource = this.execute(`get ${id}`);
-    return resource;
   }
 
   private async handleDidChangeConfiguration(e: vscode.ConfigurationChangeEvent) {

--- a/src/test/suite/stripeClient.test.ts
+++ b/src/test/suite/stripeClient.test.ts
@@ -18,7 +18,7 @@ suite('stripeClient', () => {
     sandbox.restore();
   });
 
-  suite('detectInstalled', () => {
+  suite('getCLIPath', () => {
     suite('with default CLI install path', () => {
       const osPathPairs: [utils.OSType, string][] = [
         [utils.OSType.linux, '/usr/local/bin/stripe'],
@@ -44,21 +44,19 @@ suite('stripeClient', () => {
           test('detects installed', async () => {
             statStub.returns(Promise.resolve({isFile: () => true})); // the path is a file; CLI found
             const stripeClient = new StripeClient(new NoOpTelemetry());
-            const isInstalled = await stripeClient.detectInstalled();
-            assert.strictEqual(isInstalled, true);
+            const cliPath = await stripeClient.getCLIPath();
+            assert.strictEqual(cliPath, path);
             assert.deepStrictEqual(realpathStub.args[0], [path]);
             assert.deepStrictEqual(statStub.args[0], [resolvedPath]);
-            assert.strictEqual(stripeClient.cliPath, path);
           });
 
           test('detects not installed', async () => {
             statStub.returns(Promise.resolve({isFile: () => false})); // the path is not a file; CLI not found
             const stripeClient = new StripeClient(new NoOpTelemetry());
-            const isInstalled = await stripeClient.detectInstalled();
-            assert.strictEqual(isInstalled, false);
+            const cliPath = await stripeClient.getCLIPath();
+            assert.strictEqual(cliPath, null);
             assert.deepStrictEqual(realpathStub.args[0], [path]);
             assert.deepStrictEqual(statStub.args[0], [resolvedPath]);
-            assert.strictEqual(stripeClient.cliPath, null);
           });
         });
       });
@@ -67,8 +65,8 @@ suite('stripeClient', () => {
         sandbox.stub(fs.promises, 'stat').returns(Promise.resolve({isFile: () => false}));
         const showErrorMessageSpy = sandbox.stub(vscode.window, 'showErrorMessage');
         const stripeClient = new StripeClient(new NoOpTelemetry());
-        const isInstalled = await stripeClient.detectInstalled();
-        assert.strictEqual(isInstalled, false);
+        const cliPath = await stripeClient.getCLIPath();
+        assert.strictEqual(cliPath, null);
         assert.deepStrictEqual(
           showErrorMessageSpy.args[0],
           [
@@ -108,21 +106,19 @@ suite('stripeClient', () => {
           test('detects installed', async () => {
             statStub.returns(Promise.resolve({isFile: () => true})); // the path is a file; CLI found
             const stripeClient = new StripeClient(new NoOpTelemetry());
-            const isInstalled = await stripeClient.detectInstalled();
-            assert.strictEqual(isInstalled, true);
+            const cliPath = await stripeClient.getCLIPath();
+            assert.strictEqual(cliPath, customPath);
             assert.deepStrictEqual(realpathStub.args[0], [customPath]);
             assert.deepStrictEqual(statStub.args[0], [resolvedPath]);
-            assert.strictEqual(stripeClient.cliPath, customPath);
           });
 
           test('detects not installed', async () => {
             statStub.returns(Promise.resolve({isFile: () => false})); // the path is not a file; CLI not found
             const stripeClient = new StripeClient(new NoOpTelemetry());
-            const isInstalled = await stripeClient.detectInstalled();
-            assert.strictEqual(isInstalled, false);
+            const cliPath = await stripeClient.getCLIPath();
+            assert.strictEqual(cliPath, null);
             assert.deepStrictEqual(realpathStub.args[0], [customPath]);
             assert.deepStrictEqual(statStub.args[0], [resolvedPath]);
-            assert.strictEqual(stripeClient.cliPath, null);
           });
         });
       });
@@ -131,8 +127,8 @@ suite('stripeClient', () => {
         statStub.returns(Promise.resolve({isFile: () => false}));
         const showErrorMessageSpy = sandbox.stub(vscode.window, 'showErrorMessage');
         const stripeClient = new StripeClient(new NoOpTelemetry());
-        const isInstalled = await stripeClient.detectInstalled();
-        assert.strictEqual(isInstalled, false);
+        const cliPath = await stripeClient.getCLIPath();
+        assert.strictEqual(cliPath, null);
         assert.deepStrictEqual(
           showErrorMessageSpy.args[0],
           ["You set a custom installation path for the Stripe CLI, but we couldn't find the executable in '/foo/bar/baz'", 'Ok'],


### PR DESCRIPTION
### Notify
cc @stripe/developer-products 

### Summary
Instead of using the string `stripe`, use the full path to the CLI executable to run Stripe commands in the vscode terminal. We already use this path when detecting if the user has the CLI installed. This also means our commands will use the user's `stripe.cliInstallPath` setting if they set a custom path.

To achieve this, we made `StripeTerminal` depend on `StripeClient` and added a public method to `StripeClient` to get the CLI path.

Screenshots:
![Screen Shot 2021-01-28 at 4 10 00 PM](https://user-images.githubusercontent.com/71457708/106214848-87643200-6184-11eb-9f31-25a4a1c10bb3.png)
Clicked **Start API logs streaming**; default path was used.

![Screen Shot 2021-01-28 at 4 10 50 PM](https://user-images.githubusercontent.com/71457708/106214853-89c68c00-6184-11eb-9f1e-1237975be64b.png)
Clicked **Start API logs streaming**; custom path was used.

![Screen Shot 2021-01-28 at 4 11 39 PM](https://user-images.githubusercontent.com/71457708/106214867-90550380-6184-11eb-97f8-d175435202a9.png)
Clicked **Start API logs streaming** but CLI wasn't installed; prompt for install.

![Screen Shot 2021-01-28 at 4 11 12 PM](https://user-images.githubusercontent.com/71457708/106214860-8d5a1300-6184-11eb-853b-9a34ee5f477d.png)
Clicked **Start API logs streaming** but CLI wasn't at custom path; show error message.

![Screen Shot 2021-01-28 at 4 12 22 PM](https://user-images.githubusercontent.com/71457708/106214871-92b75d80-6184-11eb-91f3-1ec20eda0b85.png)
A user can still listen for events and stream logs simultaneously.

### Motivation
Fixes #92 

### Testing
- Added tests to check that the `StripeTerminal` class will run commands with `/usr/local/bin/stripe` or a custom path
- Updated tests for `StripeClient` to reflect its new public interface
- Manually verified; see screenshots