### PR TITLE
Create Git class to check if the user's workspace is using git

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,6 +2,7 @@ import {ExtensionContext, commands, debug, env, window, workspace} from 'vscode'
 import {GATelemetry, LocalTelemetry} from './telemetry';
 import {ServerOptions, TransportKind} from 'vscode-languageclient';
 import {Commands} from './commands';
+import {Git} from './git';
 import {Resource} from './resources';
 import {StripeClient} from './stripeClient';
 import {StripeDashboardViewDataProvider} from './stripeDashboardView';
@@ -70,8 +71,10 @@ export function activate(this: any, context: ExtensionContext) {
     new StripeEventTextDocumentContentProvider(stripeClient)
   );
 
+  const git = new Git();
+
   // Stripe Linter
-  const stripeLinter = new StripeLinter(telemetry);
+  const stripeLinter = new StripeLinter(telemetry, git);
   stripeLinter.activate();
 
   // Language Server for hover matching of Stripe methods

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,0 +1,19 @@
+import * as fs from 'fs';
+import {Uri, workspace} from 'vscode';
+import path from 'path';
+
+export class Git {
+  public async isGitRepo(uri: Uri): Promise<boolean> {
+    const workspaceFolder = workspace.getWorkspaceFolder(uri);
+    if (!workspaceFolder) {
+      return false;
+    }
+    const dotGitPath = path.resolve(workspaceFolder.uri.fsPath, '.git');
+    try {
+      await fs.promises.access(dotGitPath, fs.constants.F_OK);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/src/stripeLinter.ts
+++ b/src/stripeLinter.ts
@@ -98,11 +98,7 @@ export class StripeLinter {
 
     const message = await this.git.isGitRepo(document.uri) ? diagnosticMessageGit : diagnosticMessageNoGit;
 
-    // get each line's possible API key warnings
-    // then flatten nested diagnostics into a flat array
-    const fileDiagnostics: Diagnostic[] = lines
-      .map(this.prepareLineDiagnostics(message))
-      .reduce((acc, next) => acc.concat([...next]), []);
+    const fileDiagnostics: Diagnostic[] = lines.flatMap(this.prepareLineDiagnostics(message));
 
     // tell VS Code to show warnings and errors in syntax
     diagnosticCollection.set(document.uri, fileDiagnostics);

--- a/src/stripeLinter.ts
+++ b/src/stripeLinter.ts
@@ -82,9 +82,9 @@ export class StripeLinter {
     this.git = git;
   }
 
-  activate() {
+  async activate() {
     if (window.activeTextEditor) {
-      this.lookForHardCodedAPIKeys(window.activeTextEditor.document);
+      await this.lookForHardCodedAPIKeys(window.activeTextEditor.document);
     }
     workspace.onDidSaveTextDocument(this.lookForHardCodedAPIKeys);
   }

--- a/src/test/suite/git.test.ts
+++ b/src/test/suite/git.test.ts
@@ -1,0 +1,47 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+import {Git} from '../../git';
+
+suite('git', () => {
+  let sandbox: sinon.SinonSandbox;
+
+  setup(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  teardown(() => {
+    sandbox.restore();
+  });
+
+  suite('isGitRepo', () => {
+    const workspaceFolder = path.resolve('/', 'foo');
+    const dotGitPath = path.resolve(workspaceFolder, '.git');
+    const filePath = path.resolve(workspaceFolder, 'baz');
+    const fileUri = vscode.Uri.parse(`file://${filePath}`);
+
+    setup(() => {
+      sandbox.stub(vscode.workspace, 'getWorkspaceFolder')
+        .withArgs(fileUri)
+        .returns(<any>{uri: {fsPath: workspaceFolder}});
+    });
+
+    test('identifies a workspace initialized with git', async () => {
+      sandbox.stub(fs.promises, 'access')
+        .withArgs(dotGitPath, fs.constants.F_OK)
+        .resolves();
+      const git = new Git();
+      assert.strictEqual(await git.isGitRepo(fileUri), true);
+    });
+
+    test('identifies a workspace without git', async () => {
+      sandbox.stub(fs.promises, 'access')
+        .withArgs(dotGitPath, fs.constants.F_OK)
+        .rejects();
+      const git = new Git();
+      assert.strictEqual(await git.isGitRepo(fileUri), false);
+    });
+  });
+});

--- a/src/test/suite/stripeLinter.test.ts
+++ b/src/test/suite/stripeLinter.test.ts
@@ -30,7 +30,7 @@ suite('StripeLinter', () => {
       const telemetrySpy = sandbox.spy(telemetry, 'sendEvent');
 
       const linter = new stripeLinter.StripeLinter(telemetry, git);
-      linter.activate();
+      await linter.activate();
 
       const diagnostics = vscode.languages.getDiagnostics();
       assert.strictEqual(shouldSearchStub.calledOnce, true);
@@ -47,7 +47,7 @@ suite('StripeLinter', () => {
       const telemetrySpy = sandbox.spy(telemetry, 'sendEvent');
 
       const linter = new stripeLinter.StripeLinter(telemetry, git);
-      linter.activate();
+      await linter.activate();
       const diagnostics: vscode.Diagnostic[] = vscode.languages.getDiagnostics(document.uri);
 
       assert.strictEqual(shouldSearchStub.calledOnce, true);
@@ -65,7 +65,7 @@ suite('StripeLinter', () => {
       const telemetrySpy = sandbox.spy(telemetry, 'sendEvent');
 
       const linter = new stripeLinter.StripeLinter(telemetry, git);
-      linter.activate();
+      await linter.activate();
       const diagnostics: vscode.Diagnostic[] = vscode.languages.getDiagnostics(document.uri);
 
       assert.strictEqual(shouldSearchStub.calledOnce, true);

--- a/src/test/suite/stripeLinter.test.ts
+++ b/src/test/suite/stripeLinter.test.ts
@@ -3,11 +3,13 @@ import * as assert from 'assert';
 import * as sinon from 'sinon';
 import * as stripeLinter from '../../stripeLinter';
 import * as vscode from 'vscode';
+import {Git} from '../../git';
 import {NoOpTelemetry} from '../../telemetry';
 
 suite('StripeLinter', () => {
   let sandbox: sinon.SinonSandbox;
   const telemetry = new NoOpTelemetry();
+  const git = new Git();
 
   setup(() => {
     sandbox = sinon.createSandbox();
@@ -27,7 +29,7 @@ suite('StripeLinter', () => {
       const shouldSearchStub = sandbox.stub(stripeLinter, 'shouldSearchFile').returns(false);
       const telemetrySpy = sandbox.spy(telemetry, 'sendEvent');
 
-      const linter = new stripeLinter.StripeLinter(telemetry);
+      const linter = new stripeLinter.StripeLinter(telemetry, git);
       linter.activate();
 
       const diagnostics = vscode.languages.getDiagnostics();
@@ -44,7 +46,7 @@ suite('StripeLinter', () => {
       const shouldSearchStub = sandbox.stub(stripeLinter, 'shouldSearchFile').returns(true);
       const telemetrySpy = sandbox.spy(telemetry, 'sendEvent');
 
-      const linter = new stripeLinter.StripeLinter(telemetry);
+      const linter = new stripeLinter.StripeLinter(telemetry, git);
       linter.activate();
       const diagnostics: vscode.Diagnostic[] = vscode.languages.getDiagnostics(document.uri);
 
@@ -62,7 +64,7 @@ suite('StripeLinter', () => {
       const shouldSearchStub = sandbox.stub(stripeLinter, 'shouldSearchFile').returns(true);
       const telemetrySpy = sandbox.spy(telemetry, 'sendEvent');
 
-      const linter = new stripeLinter.StripeLinter(telemetry);
+      const linter = new stripeLinter.StripeLinter(telemetry, git);
       linter.activate();
       const diagnostics: vscode.Diagnostic[] = vscode.languages.getDiagnostics(document.uri);
 


### PR DESCRIPTION
### Notify
@stripe/developer-products 

### Summary
To check if the user is using git, check if the workspace root contains a `.git` folder rather than checking if the vscode git extension is enabled.

We put git-related logic in a new `Git` class and have the `StripeLinter` depend on it. A little bit of refactoring in `StripeLinter` was needed to achieve this.

This does not completely remove the dependency on the vscode git extension because we are still using it to check for which files to lint, but this will be fixed in the next PR.

### Motivation
We want to know if the user is using git because we want show different error messages with our linter, but we want to do it without depending on the user having the vscode git extension.

### Testing
- Added tests for the `Git` class to verify it recognizes a workspace with and without a `.git` folder
- Manually verified that the linter messages would differ whether I had `.git` or not
