### PR TITLE
Check if file is git-ignored before linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "Snippets"
   ],
   "extensionKind": [
-    "ui"
+    "workspace"
   ],
   "keywords": [
     "stripe",
@@ -60,9 +60,6 @@
     "onLanguage:ruby",
     "onLanguage:java",
     "onLanguage:php"
-  ],
-  "extensionDependencies": [
-    "vscode.git"
   ],
   "main": "./out/extension.js",
   "contributes": {

--- a/src/git.ts
+++ b/src/git.ts
@@ -2,6 +2,8 @@ import * as fs from 'fs';
 import {Uri, workspace} from 'vscode';
 import path from 'path';
 
+const {spawn} = require('child_process');
+
 export class Git {
   public async isGitRepo(uri: Uri): Promise<boolean> {
     const workspaceFolder = workspace.getWorkspaceFolder(uri);
@@ -15,5 +17,23 @@ export class Git {
     } catch {
       return false;
     }
+  }
+
+  public isIgnored(uri: Uri): Promise<boolean> {
+    return new Promise((resolve) => {
+      const workspaceFolder = workspace.getWorkspaceFolder(uri);
+      if (!workspaceFolder) {
+        resolve(false);
+        return;
+      }
+      try {
+        const gitCheckIgnore = spawn('git', ['check-ignore', uri.fsPath], {cwd: workspaceFolder.uri.fsPath});
+        gitCheckIgnore.on('close', (code: number) => {
+          resolve(code === 0);
+        });
+      } catch {
+        resolve(false);
+      }
+    });
   }
 }

--- a/src/test/suite/stripeLinter.test.ts
+++ b/src/test/suite/stripeLinter.test.ts
@@ -1,10 +1,10 @@
 
 import * as assert from 'assert';
 import * as sinon from 'sinon';
-import * as stripeLinter from '../../stripeLinter';
 import * as vscode from 'vscode';
 import {Git} from '../../git';
 import {NoOpTelemetry} from '../../telemetry';
+import {StripeLinter} from '../../stripeLinter';
 
 suite('StripeLinter', () => {
   let sandbox: sinon.SinonSandbox;
@@ -21,19 +21,19 @@ suite('StripeLinter', () => {
 
   suite('lookForHardCodedAPIKeys', () => {
 
-    test('Editor content is not searched when shoudSearchFile returns false', async() => {
+    test('Editor content is not searched when file is git-ignored', async() => {
       const options = {content: 'I have content with critical data : sk_live_1234'};
       await vscode.workspace.openTextDocument(options)
         .then((doc) => vscode.window.showTextDocument(doc, {preview: false}));
 
-      const shouldSearchStub = sandbox.stub(stripeLinter, 'shouldSearchFile').returns(false);
+      const isIgnoredStub = sandbox.stub(git, 'isIgnored').resolves(true);
       const telemetrySpy = sandbox.spy(telemetry, 'sendEvent');
 
-      const linter = new stripeLinter.StripeLinter(telemetry, git);
+      const linter = new StripeLinter(telemetry, git);
       await linter.activate();
 
       const diagnostics = vscode.languages.getDiagnostics();
-      assert.strictEqual(shouldSearchStub.calledOnce, true);
+      assert.strictEqual(isIgnoredStub.calledOnce, true);
       assert.strictEqual(telemetrySpy.callCount, 0);
       assert.strictEqual(diagnostics.length, 0);
     });
@@ -43,14 +43,14 @@ suite('StripeLinter', () => {
       const document = await vscode.workspace.openTextDocument(options);
       await vscode.window.showTextDocument(document, {preview: false});
 
-      const shouldSearchStub = sandbox.stub(stripeLinter, 'shouldSearchFile').returns(true);
+      const isIgnoredStub = sandbox.stub(git, 'isIgnored').resolves(false);
       const telemetrySpy = sandbox.spy(telemetry, 'sendEvent');
 
-      const linter = new stripeLinter.StripeLinter(telemetry, git);
+      const linter = new StripeLinter(telemetry, git);
       await linter.activate();
       const diagnostics: vscode.Diagnostic[] = vscode.languages.getDiagnostics(document.uri);
 
-      assert.strictEqual(shouldSearchStub.calledOnce, true);
+      assert.strictEqual(isIgnoredStub.calledOnce, true);
       assert.strictEqual(telemetrySpy.calledOnce, true);
       assert.deepStrictEqual(telemetrySpy.args[0], ['diagnostics.show', vscode.DiagnosticSeverity.Error]);
       assert.strictEqual(diagnostics.length, 1);
@@ -61,14 +61,14 @@ suite('StripeLinter', () => {
       const document = await vscode.workspace.openTextDocument(options);
       await vscode.window.showTextDocument(document, {preview: false});
 
-      const shouldSearchStub = sandbox.stub(stripeLinter, 'shouldSearchFile').returns(true);
+      const isIgnoredStub = sandbox.stub(git, 'isIgnored').resolves(false);
       const telemetrySpy = sandbox.spy(telemetry, 'sendEvent');
 
-      const linter = new stripeLinter.StripeLinter(telemetry, git);
+      const linter = new StripeLinter(telemetry, git);
       await linter.activate();
       const diagnostics: vscode.Diagnostic[] = vscode.languages.getDiagnostics(document.uri);
 
-      assert.strictEqual(shouldSearchStub.calledOnce, true);
+      assert.strictEqual(isIgnoredStub.calledOnce, true);
       assert.strictEqual(telemetrySpy.callCount, 0);
       assert.strictEqual(diagnostics.length, 0);
     });


### PR DESCRIPTION
### Notify
cc @stripe/developer-products 

### Summary
- Before: We depend on the user having the git vscode extension installed in order to check if a file should be linted or not.
- After: Don't use the git vscode extension to check if a file should be linted. Instead, check if the file is ignored by spawning a child process with `git check-ignore <file>`. If ignored, don't lint.

### Motivation
- Fixes #96, where API keys that are already committed are not being linted.
- Also removes a dependency on the git vscode extension.

### Testing
- Updated linter tests
- Unsure how to test the `isIgnored` method in isolation, so tested manually
- Verified manually that API keys that are already committed are linted, and git-ignored files are not linted