### PR TITLE
Add methods for spawning and ending a Stripe CLI child process (only support `stripe logs tail` for now)

### DIFF
--- a/src/stripeClient.ts
+++ b/src/stripeClient.ts
@@ -20,7 +20,7 @@ const stripeProcessNameToArgsMap: Map<StripeProcessName, string[]> = new Map([
 export class StripeClient {
   telemetry: Telemetry;
   private cliPath: string | null;
-  private stripeProcesses: Map<StripeProcessName, ChildProcess>;
+  stripeProcesses: Map<StripeProcessName, ChildProcess>;
 
   constructor(telemetry: Telemetry) {
     this.telemetry = telemetry;
@@ -150,6 +150,15 @@ export class StripeClient {
 
     const newStripeProcess = spawn(cliPath, [...commandArgs, ...allFlags]);
     this.stripeProcesses.set(stripeProcessName, newStripeProcess);
+
+    newStripeProcess.on('exit', () => {
+      this.stripeProcesses.delete(stripeProcessName);
+    });
+
+    newStripeProcess.on('error', () => {
+      this.stripeProcesses.delete(stripeProcessName);
+    });
+
     return newStripeProcess;
   }
 

--- a/src/stripeClient.ts
+++ b/src/stripeClient.ts
@@ -151,13 +151,8 @@ export class StripeClient {
     const newStripeProcess = spawn(cliPath, [...commandArgs, ...allFlags]);
     this.stripeProcesses.set(stripeProcessName, newStripeProcess);
 
-    newStripeProcess.on('exit', () => {
-      this.stripeProcesses.delete(stripeProcessName);
-    });
-
-    newStripeProcess.on('error', () => {
-      this.stripeProcesses.delete(stripeProcessName);
-    });
+    newStripeProcess.on('close', () => this.cleanupStripeProcess(stripeProcessName));
+    newStripeProcess.on('error', () => this.cleanupStripeProcess(stripeProcessName));
 
     return newStripeProcess;
   }
@@ -166,9 +161,13 @@ export class StripeClient {
     const existingStripeProcess = this.stripeProcesses.get(stripeProcessName);
     if (existingStripeProcess) {
       existingStripeProcess.kill();
-      this.stripeProcesses.delete(stripeProcessName);
+      this.cleanupStripeProcess(stripeProcessName);
     }
   }
+
+  private cleanupStripeProcess = (stripeProcessName: StripeProcessName) => {
+    this.stripeProcesses.delete(stripeProcessName);
+  };
 
   private async detectInstalled() {
     const defaultInstallPath = (() => {

--- a/src/stripeClient.ts
+++ b/src/stripeClient.ts
@@ -161,7 +161,6 @@ export class StripeClient {
     const cliProcess = this.cliProcesses.get(cliCommand);
     if (cliProcess) {
       cliProcess.kill();
-      this.cleanupCLIProcess(cliCommand);
     }
   }
 

--- a/src/stripeClient.ts
+++ b/src/stripeClient.ts
@@ -158,9 +158,9 @@ export class StripeClient {
   }
 
   endCLIProcess(cliCommand: CLICommand): void {
-    const existingStripeProcess = this.cliProcesses.get(cliCommand);
-    if (existingStripeProcess) {
-      existingStripeProcess.kill();
+    const cliProcess = this.cliProcesses.get(cliCommand);
+    if (cliProcess) {
+      cliProcess.kill();
       this.cleanupCLIProcess(cliCommand);
     }
   }

--- a/src/test/suite/stripeClient.test.ts
+++ b/src/test/suite/stripeClient.test.ts
@@ -2,7 +2,7 @@ import * as assert from 'assert';
 import * as sinon from 'sinon';
 import * as utils from '../../utils';
 import * as vscode from 'vscode';
-import {StripeClient, StripeProcess} from '../../stripeClient';
+import {StripeClient, StripeProcessName} from '../../stripeClient';
 import {NoOpTelemetry} from '../../telemetry';
 import childProcess from 'child_process';
 
@@ -149,7 +149,7 @@ suite('stripeClient', () => {
       const stripeClient = new StripeClient(new NoOpTelemetry());
       sandbox.stub(stripeClient, 'getCLIPath').resolves('path/to/stripe');
       const stripeLogsTailProcess = await stripeClient.getOrCreateStripeProcess(
-        StripeProcess.LogsTail,
+        StripeProcessName.LogsTail,
       );
       assert.strictEqual(spawnStub.callCount, 1);
       assert.deepStrictEqual(spawnStub.args[0], ['path/to/stripe', ['logs', 'tail']]);
@@ -160,10 +160,10 @@ suite('stripeClient', () => {
       const stripeClient = new StripeClient(new NoOpTelemetry());
       sandbox.stub(stripeClient, 'getCLIPath').resolves('path/to/stripe');
       const stripeLogsTailProcess = await stripeClient.getOrCreateStripeProcess(
-        StripeProcess.LogsTail,
+        StripeProcessName.LogsTail,
       );
       const stripeLogsTailProcess2 = await stripeClient.getOrCreateStripeProcess(
-        StripeProcess.LogsTail,
+        StripeProcessName.LogsTail,
       );
       assert.strictEqual(spawnStub.callCount, 1);
       assert.deepStrictEqual(spawnStub.args[0], ['path/to/stripe', ['logs', 'tail']]);
@@ -175,7 +175,7 @@ suite('stripeClient', () => {
       const stripeClient = new StripeClient(new NoOpTelemetry());
       sandbox.stub(stripeClient, 'getCLIPath').resolves('path/to/stripe');
       const stripeLogsTailProcess = await stripeClient.getOrCreateStripeProcess(
-        StripeProcess.LogsTail,
+        StripeProcessName.LogsTail,
         flags,
       );
       assert.strictEqual(spawnStub.callCount, 1);
@@ -190,13 +190,13 @@ suite('stripeClient', () => {
       const stripeClient = new StripeClient(new NoOpTelemetry());
       sandbox.stub(stripeClient, 'getCLIPath').resolves('path/to/stripe');
       const stripeLogsTailProcess = await stripeClient.getOrCreateStripeProcess(
-        StripeProcess.LogsTail,
+        StripeProcessName.LogsTail,
       );
       if (!stripeLogsTailProcess) {
         throw new assert.AssertionError();
       }
       const killStub = sandbox.stub(stripeLogsTailProcess, 'kill');
-      stripeClient.endStripeProcess(StripeProcess.LogsTail);
+      stripeClient.endStripeProcess(StripeProcessName.LogsTail);
       assert.strictEqual(killStub.callCount, 1);
     });
   });

--- a/src/test/suite/stripeClient.test.ts
+++ b/src/test/suite/stripeClient.test.ts
@@ -209,7 +209,7 @@ suite('stripeClient', () => {
     });
 
     suite('on child process events', () => {
-      ['exit', 'error'].forEach((event) => {
+      ['close', 'error'].forEach((event) => {
         test(`on ${event}, removes child process`, async () => {
           const stripeClient = new StripeClient(new NoOpTelemetry());
           sandbox.stub(stripeClient, 'getCLIPath').resolves('path/to/stripe');

--- a/src/test/suite/stripeClient.test.ts
+++ b/src/test/suite/stripeClient.test.ts
@@ -138,17 +138,17 @@ suite('stripeClient', () => {
     });
   });
 
-  suite('stripe processes', () => {
+  suite('CLI processes', () => {
     let spawnStub: sinon.SinonStub;
-    let stripeProcessStub: childProcess.ChildProcess;
+    let cliProcessStub: childProcess.ChildProcess;
 
     setup(() => {
-      stripeProcessStub = <childProcess.ChildProcess>new EventEmitter();
-      stripeProcessStub.stdin = new Writable();
-      stripeProcessStub.stdout = <Readable>new EventEmitter();
-      stripeProcessStub.stderr = <Readable>new EventEmitter();
-      stripeProcessStub.kill = () => {};
-      spawnStub = sandbox.stub(childProcess, 'spawn').returns(stripeProcessStub);
+      cliProcessStub = <childProcess.ChildProcess>new EventEmitter();
+      cliProcessStub.stdin = new Writable();
+      cliProcessStub.stdout = <Readable>new EventEmitter();
+      cliProcessStub.stderr = <Readable>new EventEmitter();
+      cliProcessStub.kill = () => {};
+      spawnStub = sandbox.stub(childProcess, 'spawn').returns(cliProcessStub);
     });
 
     test('spawns a child process with stripe logs tail', async () => {

--- a/src/test/suite/stripeClient.test.ts
+++ b/src/test/suite/stripeClient.test.ts
@@ -197,7 +197,6 @@ suite('stripeClient', () => {
       assert.strictEqual(stripeClient.cliProcesses.has(CLICommand.LogsTail), true);
       stripeClient.endCLIProcess(CLICommand.LogsTail);
       assert.strictEqual(killStub.callCount, 1);
-      assert.strictEqual(stripeClient.cliProcesses.has(CLICommand.LogsTail), false);
     });
 
     suite('on child process events', () => {


### PR DESCRIPTION
### Notify
cc @stripe/developer-products 

### Summary
Added two methods to `StripeClient`:
- `getOrCreateStripeProcess: (StripeProcess) => Promise<ChildProcess>`
  -  Spawns a "singleton" child process running a stripe CLI command (currently only supports `stripe logs tail`).
- `endStripeProcess: (StripeProcess) => void`
  - Ends the process if it exists

These methods will be used in `StripeLogsView` in a separate PR in order to stream logs in the UI.

### Motivation
From #84, we want to stream logs in the UI rather than in the VS Code terminal. This will be done over several PRs.

### Testing
- Added tests to verify:
  - it spawns a `stripe logs tail` process
  - it reuses the process if it already exists
  - it passes flags to the process
  - it ends the process