### PR TITLE
Add CLI install path on M1 Macs

### DIFF
--- a/src/stripeClient.ts
+++ b/src/stripeClient.ts
@@ -119,8 +119,11 @@ export class StripeClient {
       const osType: OSType = getOSType();
       switch (osType) {
         case OSType.macOS:
-          // HomeBrew install path on macOS
+          // HomeBrew install path on macOS Intel Macs
           return '/usr/local/bin/stripe';
+        case OSType.macOSapple:
+          // HomeBrew install path on macOS M1 Macs
+          return '/opt/homebrew/Cellar/stripe';
         case OSType.linux:
           // apt-get install path on ubuntu + yum install path on centOS
           return '/usr/local/bin/stripe';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,9 @@
 import * as vscode from 'vscode';
+const os = require('os'); // Not sure if this is needed/will work
 
 export enum OSType {
   macOS = 'macOS',
+  macOSapple = 'macOSapple', // Need a new OSType value for M1 Macs because Homebrew uses a different directory than on Intel Macs
   linux = 'linux',
   unknown = 'unknown',
   windows = 'windows',
@@ -18,11 +20,18 @@ export function getExtensionInfo() {
 
 export function getOSType(): OSType {
   const platform: string = process.platform;
+  
+  const cpus = os.cpus(); // Returns an array of all CPU cores
+  const cpu: string = cpus[0]model; // Copying syntax of line 22, not sure if this will work
 
   if (/^win/.test(platform)) {
     return OSType.windows;
   } else if (/^darwin/.test(platform)) {
-    return OSType.macOS;
+    if(/^Apple/.test(cpu)) { // Adding a CPU type check if MacOS 
+      return OSType.macOSapple;
+    } else {
+      return OSType.macOS;
+    }
   } else if (/^linux/.test(platform)) {
     return OSType.linux;
   } else {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -22,7 +22,7 @@ export function getOSType(): OSType {
   const platform: string = process.platform;
   
   const cpus = os.cpus(); // Returns an array of all CPU cores
-  const cpu: string = cpus[0]model; // Copying syntax of line 22, not sure if this will work
+  const cpu: string = cpus[0].model; // Copying syntax of line 22, not sure if this will work
 
   if (/^win/.test(platform)) {
     return OSType.windows;


### PR DESCRIPTION
Fixes #166 which describes how the Stripe VS Code Extension cannot find the Stripe CLI on M1 Macs because the homebrew install path is different from on Intel Macs (see https://docs.brew.sh/Installation).

I don't know TypeScript, so I tried as best I could to copy existing syntax. Also, I didn't check to see if `OSType` or  `defautInstallPath` are used anywhere else that might be broken by these changes. Finally, I did not test any of my changes locally beyond a local prototype in Node.

As such, **please consider this PR more of a Proof of Concept for the fix** and confirm my changes actually work before merging :-)
  