### PR TITLE
Refactor StripeTreeItem constructor

### DIFF
--- a/src/stripeDashboardView.ts
+++ b/src/stripeDashboardView.ts
@@ -6,7 +6,9 @@ export class StripeDashboardViewDataProvider extends StripeTreeViewDataProvider 
   buildTree(): Promise<StripeTreeItem[]> {
     const items = [];
 
-    const apiKeysItem = new StripeTreeItem('Open API keys page', 'openDashboardApikeys');
+    const apiKeysItem = new StripeTreeItem('Open API keys page', {
+      commandString: 'openDashboardApikeys',
+    });
     apiKeysItem.setIcon({
       dark: Resource.ICONS.dark.linkExternal,
       light: Resource.ICONS.light.linkExternal,
@@ -14,7 +16,9 @@ export class StripeDashboardViewDataProvider extends StripeTreeViewDataProvider 
 
     items.push(apiKeysItem);
 
-    const eventsItem = new StripeTreeItem('Open events page', 'openDashboardEvents');
+    const eventsItem = new StripeTreeItem('Open events page', {
+      commandString: 'openDashboardEvents',
+    });
     eventsItem.setIcon({
       dark: Resource.ICONS.dark.linkExternal,
       light: Resource.ICONS.light.linkExternal,
@@ -22,7 +26,7 @@ export class StripeDashboardViewDataProvider extends StripeTreeViewDataProvider 
 
     items.push(eventsItem);
 
-    const logItem = new StripeTreeItem('Open API logs page', 'openDashboardLogs');
+    const logItem = new StripeTreeItem('Open API logs page', {commandString: 'openDashboardLogs'});
     logItem.setIcon({
       dark: Resource.ICONS.dark.linkExternal,
       light: Resource.ICONS.light.linkExternal,
@@ -30,7 +34,9 @@ export class StripeDashboardViewDataProvider extends StripeTreeViewDataProvider 
 
     items.push(logItem);
 
-    const webhooksItem = new StripeTreeItem('Open webhooks page', 'openDashboardWebhooks');
+    const webhooksItem = new StripeTreeItem('Open webhooks page', {
+      commandString: 'openDashboardWebhooks',
+    });
 
     webhooksItem.setIcon({
       dark: Resource.ICONS.dark.linkExternal,

--- a/src/stripeEventsView.ts
+++ b/src/stripeEventsView.ts
@@ -21,12 +21,11 @@ export class StripeEventsDataProvider extends StripeTreeViewDataProvider {
       if (events.data) {
         events.data.forEach((event: any) => {
           const title = event.type;
-          const eventItem = new StripeTreeItem(
-            title,
-            'openEventDetails',
-            new Date(event.created * 1000).toString(),
-            'eventItem',
-          );
+          const eventItem = new StripeTreeItem(title, {
+            commandString: 'openEventDetails',
+            contextValue: 'eventItem',
+            tooltip: new Date(event.created * 1000).toString(),
+          });
           eventItem.metadata = {
             type: event.type,
             id: event.id,
@@ -36,13 +35,17 @@ export class StripeEventsDataProvider extends StripeTreeViewDataProvider {
       }
     } catch (e) {}
 
-    const triggerEventItem = new StripeTreeItem('Trigger new event', 'openTriggerEvent');
+    const triggerEventItem = new StripeTreeItem('Trigger new event', {
+      commandString: 'openTriggerEvent',
+    });
     triggerEventItem.setIcon({
       dark: Resource.ICONS.dark.add,
       light: Resource.ICONS.light.add,
     });
 
-    const webhooksListenItem = new StripeTreeItem('Start webhooks listening', 'openWebhooksListen');
+    const webhooksListenItem = new StripeTreeItem('Start webhooks listening', {
+      commandString: 'openWebhooksListen',
+    });
     webhooksListenItem.setIcon({
       dark: Resource.ICONS.dark.terminal,
       light: Resource.ICONS.light.terminal,

--- a/src/stripeHelpView.ts
+++ b/src/stripeHelpView.ts
@@ -6,31 +6,32 @@ export class StripeHelpViewDataProvider extends StripeTreeViewDataProvider {
   buildTree(): Promise<StripeTreeItem[]> {
     const items = [];
 
-    const docsItem = new StripeTreeItem('Read documentation', 'openDocs');
+    const docsItem = new StripeTreeItem('Read documentation', {commandString: 'openDocs'});
     docsItem.setIcon({
       dark: Resource.ICONS.dark.book,
       light: Resource.ICONS.light.book,
     });
     items.push(docsItem);
 
-    const reportItem = new StripeTreeItem('Report issue', 'openReportIssue');
+    const reportItem = new StripeTreeItem('Report issue', {commandString: 'openReportIssue'});
     reportItem.setIcon({
       dark: Resource.ICONS.dark.report,
       light: Resource.ICONS.light.report,
     });
     items.push(reportItem);
 
-    const feedbackItem = new StripeTreeItem('Rate and provide feedback', 'openSurvey');
+    const feedbackItem = new StripeTreeItem('Rate and provide feedback', {
+      commandString: 'openSurvey',
+    });
     feedbackItem.setIcon({
       dark: Resource.ICONS.dark.feedback,
       light: Resource.ICONS.light.feedback,
     });
     items.push(feedbackItem);
 
-    const webhooksDebugItem = new StripeTreeItem(
-      'Configure debugging',
-      'openWebhooksDebugConfigure',
-    );
+    const webhooksDebugItem = new StripeTreeItem('Configure debugging', {
+      commandString: 'openWebhooksDebugConfigure',
+    });
     webhooksDebugItem.setIcon({
       dark: Resource.ICONS.dark.settings,
       light: Resource.ICONS.light.settings,

--- a/src/stripeLogsView.ts
+++ b/src/stripeLogsView.ts
@@ -115,7 +115,7 @@ export class StripeLogsDataProvider extends StripeTreeViewDataProvider {
     command?: string;
     iconId?: string;
   }) {
-    const item = new StripeTreeItem(label, command);
+    const item = new StripeTreeItem(label, {commandString: command});
     if (iconId) {
       item.iconPath = new ThemeIcon(iconId);
     }

--- a/src/stripeTreeItem.ts
+++ b/src/stripeTreeItem.ts
@@ -1,18 +1,25 @@
 import {TreeItem, TreeItemCollapsibleState} from 'vscode';
 
+type StripeTreeItemOptions = Pick<TreeItem, 'contextValue' | 'tooltip'> & {
+  /**
+   * The command that should be executed when the tree item is selected.
+   * Automatically prefixed with `'stripe.'`.
+   */
+  commandString?: string;
+};
+
 export class StripeTreeItem extends TreeItem {
   parent: StripeTreeItem | undefined;
   children: StripeTreeItem[] = [];
   private _metadata: object | undefined;
   private commandString: string | undefined;
 
-  constructor(label: string, commandString?: string, tooltip?: string, contextValue?: string) {
+  constructor(label: string, options: StripeTreeItemOptions = {}) {
     super(label, TreeItemCollapsibleState.None);
-    this.contextValue = 'stripe';
-    this.commandString = commandString;
+    this.contextValue = options.contextValue || 'stripe';
+    this.commandString = options.commandString;
+    this.tooltip = options.tooltip;
     this.metadata = {};
-    this.tooltip = tooltip;
-    this.contextValue = contextValue;
   }
 
   get metadata() {


### PR DESCRIPTION
The constructor for this class is getting quite long, so we refactor it for maintainability.

Before: 
- The constructor is `constructor(label: string, commandString?: string, tooltip?: string, contextValue?: string)`.

After: 
- The constructor is `constructor(label: string, options: StripeTreeItemOptions = {})`, where `StripeTreeItemOptions` is a type that extends from `vscode.TreeItem`. This allows us (contributors to the repo) to have parameter info on hover:

![Screen Shot 2021-03-04 at 11 19 41 AM](https://user-images.githubusercontent.com/71457708/110018445-23c9a900-7cdc-11eb-924f-0a6271bf50f3.png)

- Existing tests pass.
- Manually verified each of the tree items' functionalities continue to work.
