### PR TITLE
Add localized timestamps on hover to events and logs

### DIFF
--- a/src/stripeEventsView.ts
+++ b/src/stripeEventsView.ts
@@ -2,6 +2,7 @@ import {Resource} from './resources';
 import {StripeClient} from './stripeClient';
 import {StripeTreeItem} from './stripeTreeItem';
 import {StripeTreeViewDataProvider} from './stripeTreeViewDataProvider';
+import {unixToLocaleStringTZ} from './utils';
 
 export class StripeEventsDataProvider extends StripeTreeViewDataProvider {
   stripeClient: StripeClient;
@@ -24,7 +25,7 @@ export class StripeEventsDataProvider extends StripeTreeViewDataProvider {
           const eventItem = new StripeTreeItem(title, {
             commandString: 'openEventDetails',
             contextValue: 'eventItem',
-            tooltip: new Date(event.created * 1000).toString(),
+            tooltip: unixToLocaleStringTZ(event.created),
           });
           eventItem.metadata = {
             type: event.type,

--- a/src/stripeLogsView.ts
+++ b/src/stripeLogsView.ts
@@ -1,9 +1,9 @@
 import {CLICommand, StripeClient} from './stripeClient';
 import {ThemeIcon, window} from 'vscode';
+import {debounce, unixToLocaleStringTZ} from './utils';
 import {LineStream} from 'byline';
 import {StripeTreeItem} from './stripeTreeItem';
 import {StripeTreeViewDataProvider} from './stripeTreeViewDataProvider';
-import {debounce} from './utils';
 import stream from 'stream';
 
 enum ViewState {
@@ -18,6 +18,8 @@ type LogObject = {
   url: string;
   // eslint-disable-next-line camelcase
   request_id: string;
+  // eslint-disable-next-line camelcase
+  created_at: number;
 };
 
 export const isLogObject = (object: any): object is LogObject => {
@@ -168,7 +170,9 @@ export class StripeLogsDataProvider extends StripeTreeViewDataProvider {
             const object = JSON.parse(chunk);
             if (isLogObject(object)) {
               const label = `[${object.status}] ${object.method} ${object.url} [${object.request_id}]`;
-              const logTreeItem = new StripeTreeItem(label);
+              const logTreeItem = new StripeTreeItem(label, {
+                tooltip: unixToLocaleStringTZ(object.created_at),
+              });
               this.insertLog(logTreeItem);
             }
           } catch {}

--- a/src/test/suite/utils.test.ts
+++ b/src/test/suite/utils.test.ts
@@ -132,4 +132,20 @@ suite('Utils', () => {
       assert.deepStrictEqual(item, []);
     });
   });
+
+  suite('unixToLocaleStringTZ', () => {
+    const timestamp = 1614896075; // March 4, 2021, 2:14:35 PM PST
+
+    [
+      ['en', '3/4/2021, 2:14:35 PM PST'],
+      ['en-gb', '04/03/2021, 14:14:35 GMT-8'],
+      ['ja-jp', '2021/3/4 14:14:35 GMT-8'],
+    ].forEach(([lang, expectedLocaleString]) => {
+      test(`works in ${lang}`, () => {
+        sandbox.stub(vscode.env, 'language').value(lang);
+        const actualLocaleString = utils.unixToLocaleStringTZ(timestamp);
+        assert.strictEqual(actualLocaleString, expectedLocaleString);
+      });
+    });
+  });
 });

--- a/src/test/suite/utils.test.ts
+++ b/src/test/suite/utils.test.ts
@@ -132,20 +132,4 @@ suite('Utils', () => {
       assert.deepStrictEqual(item, []);
     });
   });
-
-  suite('unixToLocaleStringTZ', () => {
-    const timestamp = 1614896075; // March 4, 2021, 2:14:35 PM PST
-
-    [
-      ['en', '3/4/2021, 2:14:35 PM PST'],
-      ['en-gb', '04/03/2021, 14:14:35 GMT-8'],
-      ['ja-jp', '2021/3/4 14:14:35 GMT-8'],
-    ].forEach(([lang, expectedLocaleString]) => {
-      test(`works in ${lang}`, () => {
-        sandbox.stub(vscode.env, 'language').value(lang);
-        const actualLocaleString = utils.unixToLocaleStringTZ(timestamp);
-        assert.strictEqual(actualLocaleString, expectedLocaleString);
-      });
-    });
-  });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -85,3 +85,17 @@ export function debounce(func: (...args: any[]) => any, wait: number): (...args:
     }, wait);
   };
 }
+
+/**
+ * Convert a Unix timestamp to a string formatted to the user's VS Code locale, with a timezone suffix.
+ *
+ * Example formats:
+ * - `en-gb`: 04/03/2021, 14:14:35 GMT-8
+ * - `ja-jp`: 2021/3/4 14:14:35 GMT-8
+ *
+ * @param unix Unix timestamp in seconds
+ * @returns Locale string of the timestamp, with short timezone suffix
+ */
+export function unixToLocaleStringTZ(unix: number): string {
+  return new Date(unix * 1000).toLocaleString(vscode.env.language, {timeZoneName: 'short'});
+}


### PR DESCRIPTION
Fixes #102.

Timestamps in `en`:
![Screen Shot 2021-03-04 at 1 41 39 PM](https://user-images.githubusercontent.com/71457708/110039136-a6ab2d80-7cf5-11eb-8ed9-c828e10e9401.png)
![Screen Shot 2021-03-04 at 1 41 30 PM](https://user-images.githubusercontent.com/71457708/110039139-a743c400-7cf5-11eb-8f30-daf65a4035b5.png)

Timestamps in `en-gb`:
![Captura de pantalla 2021-03-04 a las 14 12 17](https://user-images.githubusercontent.com/71457708/110039132-a57a0080-7cf5-11eb-900d-d890ffe2938a.png)
![Captura de pantalla 2021-03-04 a las 14 12 08](https://user-images.githubusercontent.com/71457708/110039135-a6ab2d80-7cf5-11eb-8210-f9f0ddd9d2fb.png)

- ~~Added a test to verify formatting works in different locales~~
  - Removed test due to it relying on the system timezone; no easy way to set it for the tests.
- Manually verified (see screenshots)