### PR TITLE
Add link to the Dashboard for each API log

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,6 +122,11 @@
       },
       {
         "category": "Stripe",
+        "command": "stripe.openDashboardLogFromTreeItemContextMenu",
+        "title": "Open log in Dashboard"
+      },
+      {
+        "category": "Stripe",
         "command": "stripe.openDashboardLogs",
         "title": "Open Dashboard to see recent logs"
       },
@@ -216,11 +221,19 @@
         {
           "command": "stripe.resendEvent",
           "when": "viewItem == eventItem"
+        },
+        {
+          "command": "stripe.openDashboardLogFromTreeItemContextMenu",
+          "when": "viewItem == logItem"
         }
       ],
       "commandPalette": [
         {
           "command": "stripe.openDashboardEvent",
+          "when": "false"
+        },
+        {
+          "command": "stripe.openDashboardLogFromTreeItemContextMenu",
           "when": "false"
         },
         {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -161,6 +161,29 @@ export class Commands {
     vscode.env.openExternal(vscode.Uri.parse('https://dashboard.stripe.com/test/events'));
   };
 
+  /**
+   * Why are there multiple functions for opening an API log in the Stripe Dashboard?
+   * It's because this functionality is used in two places, each of which passes different arguments:
+   *
+   * If a command is in a tree item (via left-click):
+   * - Only certain arguments are passed to the function; we define what to pass.
+   *
+   * If a command is in a tree item's context menu (via right-click):
+   * - The entire tree item is passed to the function; vscode defines this behavior.
+   */
+  openDashboardLogById = (id: string) => {
+    this.telemetry.sendEvent('openDashboardLog');
+    vscode.env.openExternal(vscode.Uri.parse(`https://dashboard.stripe.com/test/logs/${id}`));
+  };
+
+  openDashboardLogFromTreeItem = (data: {id: string}) => {
+    this.openDashboardLogById(data.id);
+  };
+
+  openDashboardLogFromTreeItemContextMenu = (stripeTreeItem: StripeTreeItem) => {
+    this.openDashboardLogById(stripeTreeItem.metadata.id);
+  };
+
   openDashboardLogs = () => {
     this.telemetry.sendEvent('openDashboardLogs');
     vscode.env.openExternal(vscode.Uri.parse('https://dashboard.stripe.com/test/logs'));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -177,6 +177,20 @@ export function activate(this: any, context: ExtensionContext) {
   subscriptions.push(
     commands.registerCommand('stripe.openDashboardEvent', stripeCommands.openDashboardEvent),
   );
+
+  subscriptions.push(
+    commands.registerCommand(
+      'stripe.openDashboardLogFromTreeItem',
+      stripeCommands.openDashboardLogFromTreeItem,
+    ),
+  );
+
+  subscriptions.push(
+    commands.registerCommand(
+      'stripe.openDashboardLogFromTreeItemContextMenu',
+      stripeCommands.openDashboardLogFromTreeItemContextMenu,
+    ),
+  );
 }
 
 export function deactivate() {}

--- a/src/stripeLogsView.ts
+++ b/src/stripeLogsView.ts
@@ -171,8 +171,13 @@ export class StripeLogsDataProvider extends StripeTreeViewDataProvider {
             if (isLogObject(object)) {
               const label = `[${object.status}] ${object.method} ${object.url} [${object.request_id}]`;
               const logTreeItem = new StripeTreeItem(label, {
+                commandString: 'openDashboardLogFromTreeItem',
+                contextValue: 'logItem',
                 tooltip: unixToLocaleStringTZ(object.created_at),
               });
+              logTreeItem.metadata = {
+                id: object.request_id,
+              };
               this.insertLog(logTreeItem);
             }
           } catch {}


### PR DESCRIPTION
Add two new commands:

`stripe.openDashboardLogFromTreeItem` on left-clicking a log, open the log in the Dashboard.
![Screen Shot 2021-03-10 at 4 20 09 PM](https://user-images.githubusercontent.com/71457708/110716750-98a95100-81bc-11eb-9142-7d5ccc4523cf.png)

`stripe.openDashboardLogFromTreeItemContextMenu`: on right-clicking a log, open a context menu with a link to the log in the Dashboard.
![Screen Shot 2021-03-10 at 4 20 29 PM](https://user-images.githubusercontent.com/71457708/110716759-9c3cd800-81bc-11eb-83ff-556df13fb670.png)

There are two commands because even though they are seemingly registered to the same object, unfortunately there are differences in how the arguments are passed.