### PR TITLE
Escape `$` from snippets

### DIFF
--- a/config/snippets/php.json
+++ b/config/snippets/php.json
@@ -1,1342 +1,1342 @@
 {
   "List Customer": {
     "prefix": "StripeCustomerList",
-    "body": "$stripe->customers->all(['limit' => ${1:3}])",
+    "body": "\\$stripe->customers->all(['limit' => ${1:3}])",
     "description": "List Customer"
   },
   "Retrieve Balance Transaction": {
     "prefix": "StripeBalanceTransactionRetrieve",
-    "body": "$stripe->balanceTransactions->retrieve(\n  '${1:txn_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->balanceTransactions->retrieve(\n  '${1:txn_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Retrieve Balance Transaction"
   },
   "List Balance Transaction": {
     "prefix": "StripeBalanceTransactionList",
-    "body": "$stripe->balanceTransactions->all(['limit' => ${1:3}])",
+    "body": "\\$stripe->balanceTransactions->all(['limit' => ${1:3}])",
     "description": "List Balance Transaction"
   },
   "Create Charge": {
     "prefix": "StripeChargeCreate",
-    "body": "// `source` is obtained with Stripe.js; see https://stripe.com/docs/payments/accept-a-payment-charges#web-create-token\n$stripe->charges->create([\n  'amount' => ${1:2000},\n  'currency' => '${2:usd}',\n  'source' => '${3:tok_xxxx}',\n  'description' => '${4:My First Test Charge (created for API docs)}',\n])",
+    "body": "// `source` is obtained with Stripe.js; see https://stripe.com/docs/payments/accept-a-payment-charges#web-create-token\n\\$stripe->charges->create([\n  'amount' => ${1:2000},\n  'currency' => '${2:usd}',\n  'source' => '${3:tok_xxxx}',\n  'description' => '${4:My First Test Charge (created for API docs)}',\n])",
     "description": "Create Charge"
   },
   "Retrieve Charge": {
     "prefix": "StripeChargeRetrieve",
-    "body": "$stripe->charges->retrieve('${1:ch_xxxxxxxxxxxxx}', [])",
+    "body": "\\$stripe->charges->retrieve('${1:ch_xxxxxxxxxxxxx}', [])",
     "description": "Retrieve Charge"
   },
   "Update Charge": {
     "prefix": "StripeChargeUpdate",
-    "body": "$stripe->charges->update(\n  '${1:ch_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${2:6735}']]\n)",
+    "body": "\\$stripe->charges->update(\n  '${1:ch_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${2:6735}']]\n)",
     "description": "Update Charge"
   },
   "Capture Charge": {
     "prefix": "StripeChargeCapture",
-    "body": "$stripe->charges->capture('${1:ch_xxxxxxxxxxxxx}', [])",
+    "body": "\\$stripe->charges->capture('${1:ch_xxxxxxxxxxxxx}', [])",
     "description": "Capture Charge"
   },
   "List Charge": {
     "prefix": "StripeChargeList",
-    "body": "$stripe->charges->all(['limit' => ${1:3}])",
+    "body": "\\$stripe->charges->all(['limit' => ${1:3}])",
     "description": "List Charge"
   },
   "Create Customer": {
     "prefix": "StripeCustomerCreate",
-    "body": "$stripe->customers->create([\n  'description' => '${1:My First Test Customer (created for API docs)}',\n])",
+    "body": "\\$stripe->customers->create([\n  'description' => '${1:My First Test Customer (created for API docs)}',\n])",
     "description": "Create Customer"
   },
   "Retrieve Customer": {
     "prefix": "StripeCustomerRetrieve",
-    "body": "$stripe->customers->retrieve(\n  '${1:cus_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->customers->retrieve(\n  '${1:cus_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Retrieve Customer"
   },
   "Update Customer": {
     "prefix": "StripeCustomerUpdate",
-    "body": "$stripe->customers->update(\n  '${1:cus_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${2:6735}']]\n)",
+    "body": "\\$stripe->customers->update(\n  '${1:cus_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${2:6735}']]\n)",
     "description": "Update Customer"
   },
   "Delete Customer": {
     "prefix": "StripeCustomerDelete",
-    "body": "$stripe->customers->delete(\n  '${1:cus_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->customers->delete(\n  '${1:cus_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Delete Customer"
   },
   "Retrieve Dispute": {
     "prefix": "StripeDisputeRetrieve",
-    "body": "$stripe->disputes->retrieve(\n  '${1:dp_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->disputes->retrieve(\n  '${1:dp_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Retrieve Dispute"
   },
   "Update Dispute": {
     "prefix": "StripeDisputeUpdate",
-    "body": "$stripe->disputes->update(\n  '${1:dp_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${2:6735}']]\n)",
+    "body": "\\$stripe->disputes->update(\n  '${1:dp_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${2:6735}']]\n)",
     "description": "Update Dispute"
   },
   "Close Dispute": {
     "prefix": "StripeDisputeClose",
-    "body": "$stripe->disputes->close('${1:dp_xxxxxxxxxxxxx}', [])",
+    "body": "\\$stripe->disputes->close('${1:dp_xxxxxxxxxxxxx}', [])",
     "description": "Close Dispute"
   },
   "List Dispute": {
     "prefix": "StripeDisputeList",
-    "body": "$stripe->disputes->all(['limit' => ${1:3}])",
+    "body": "\\$stripe->disputes->all(['limit' => ${1:3}])",
     "description": "List Dispute"
   },
   "Retrieve Event": {
     "prefix": "StripeEventRetrieve",
-    "body": "$stripe->events->retrieve('${1:evt_xxxxxxxxxxxxx}', [])",
+    "body": "\\$stripe->events->retrieve('${1:evt_xxxxxxxxxxxxx}', [])",
     "description": "Retrieve Event"
   },
   "List Event": {
     "prefix": "StripeEventList",
-    "body": "$stripe->events->all(['limit' => ${1:3}])",
+    "body": "\\$stripe->events->all(['limit' => ${1:3}])",
     "description": "List Event"
   },
   "Create File": {
     "prefix": "StripeFileCreate",
-    "body": "$stripe->files->create([\n  'purpose' => '${1:dispute_xxxxxxxxxxxxx}',\n  'file' => '${2:{a file descriptor}}',\n])",
+    "body": "\\$stripe->files->create([\n  'purpose' => '${1:dispute_xxxxxxxxxxxxx}',\n  'file' => '${2:{a file descriptor}}',\n])",
     "description": "Create File"
   },
   "Retrieve File": {
     "prefix": "StripeFileRetrieve",
-    "body": "$stripe->files->retrieve('${1:file_xxxxxxxxxxxxx}', [])",
+    "body": "\\$stripe->files->retrieve('${1:file_xxxxxxxxxxxxx}', [])",
     "description": "Retrieve File"
   },
   "List File": {
     "prefix": "StripeFileList",
-    "body": "$stripe->files->all(['limit' => ${1:3}])",
+    "body": "\\$stripe->files->all(['limit' => ${1:3}])",
     "description": "List File"
   },
   "Create File Link": {
     "prefix": "StripeFileLinkCreate",
-    "body": "$stripe->fileLinks->create([\n  'file' => '${1:file_xxxxxxxxxxxxx}',\n])",
+    "body": "\\$stripe->fileLinks->create([\n  'file' => '${1:file_xxxxxxxxxxxxx}',\n])",
     "description": "Create File Link"
   },
   "Retrieve File Link": {
     "prefix": "StripeFileLinkRetrieve",
-    "body": "$stripe->fileLinks->retrieve(\n  '${1:link_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->fileLinks->retrieve(\n  '${1:link_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Retrieve File Link"
   },
   "Update File Link": {
     "prefix": "StripeFileLinkUpdate",
-    "body": "$stripe->fileLinks->update(\n  '${1:link_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${2:6735}']]\n)",
+    "body": "\\$stripe->fileLinks->update(\n  '${1:link_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${2:6735}']]\n)",
     "description": "Update File Link"
   },
   "List File Link": {
     "prefix": "StripeFileLinkList",
-    "body": "$stripe->fileLinks->all(['limit' => ${1:3}])",
+    "body": "\\$stripe->fileLinks->all(['limit' => ${1:3}])",
     "description": "List File Link"
   },
   "Retrieve Mandate": {
     "prefix": "StripeMandateRetrieve",
-    "body": "$stripe->mandates->retrieve(\n  '${1:mandate_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->mandates->retrieve(\n  '${1:mandate_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Retrieve Mandate"
   },
   "Create Payment Intent": {
     "prefix": "StripePaymentIntentCreate",
-    "body": "$stripe->paymentIntents->create([\n  'amount' => ${1:2000},\n  'currency' => '${2:usd}',\n  'payment_method_types' => ['${3:card}'],\n])",
+    "body": "\\$stripe->paymentIntents->create([\n  'amount' => ${1:2000},\n  'currency' => '${2:usd}',\n  'payment_method_types' => ['${3:card}'],\n])",
     "description": "Create Payment Intent"
   },
   "Retrieve Payment Intent": {
     "prefix": "StripePaymentIntentRetrieve",
-    "body": "$stripe->paymentIntents->retrieve(\n  '${1:pi_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->paymentIntents->retrieve(\n  '${1:pi_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Retrieve Payment Intent"
   },
   "Update Payment Intent": {
     "prefix": "StripePaymentIntentUpdate",
-    "body": "$stripe->paymentIntents->update(\n  '${1:pi_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${2:6735}']]\n)",
+    "body": "\\$stripe->paymentIntents->update(\n  '${1:pi_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${2:6735}']]\n)",
     "description": "Update Payment Intent"
   },
   "Confirm Payment Intent": {
     "prefix": "StripePaymentIntentConfirm",
-    "body": "// To create a PaymentIntent for confirmation, see our guide at: https://mock.stripe.com/docs/payments/payment-intents/creating-payment-intents#creating-for-automatic\n$stripe->paymentIntents->confirm(\n  '${1:pi_xxxxxxxxxxxxx}',\n  ['payment_method' => '${2:pm_card_visa}']\n)",
+    "body": "// To create a PaymentIntent for confirmation, see our guide at: https://mock.stripe.com/docs/payments/payment-intents/creating-payment-intents#creating-for-automatic\n\\$stripe->paymentIntents->confirm(\n  '${1:pi_xxxxxxxxxxxxx}',\n  ['payment_method' => '${2:pm_card_visa}']\n)",
     "description": "Confirm Payment Intent"
   },
   "Capture Payment Intent": {
     "prefix": "StripePaymentIntentCapture",
-    "body": "// To create a requires_capture PaymentIntent, see our guide at: https://mock.stripe.com/docs/payments/capture-later\n$stripe->paymentIntents->capture(\n  '${1:pi_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "// To create a requires_capture PaymentIntent, see our guide at: https://mock.stripe.com/docs/payments/capture-later\n\\$stripe->paymentIntents->capture(\n  '${1:pi_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Capture Payment Intent"
   },
   "Cancel Payment Intent": {
     "prefix": "StripePaymentIntentCancel",
-    "body": "// To create a PaymentIntent, see our guide at: https://mock.stripe.com/docs/payments/payment-intents/creating-payment-intents#creating-for-automatic\n$stripe->paymentIntents->cancel(\n  '${1:pi_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "// To create a PaymentIntent, see our guide at: https://mock.stripe.com/docs/payments/payment-intents/creating-payment-intents#creating-for-automatic\n\\$stripe->paymentIntents->cancel(\n  '${1:pi_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Cancel Payment Intent"
   },
   "List Payment Intent": {
     "prefix": "StripePaymentIntentList",
-    "body": "$stripe->paymentIntents->all(['limit' => ${1:3}])",
+    "body": "\\$stripe->paymentIntents->all(['limit' => ${1:3}])",
     "description": "List Payment Intent"
   },
   "Create Setup Intent": {
     "prefix": "StripeSetupIntentCreate",
-    "body": "$stripe->setupIntents->create([\n  'payment_method_types' => ['${1:card}'],\n])",
+    "body": "\\$stripe->setupIntents->create([\n  'payment_method_types' => ['${1:card}'],\n])",
     "description": "Create Setup Intent"
   },
   "Retrieve Setup Intent": {
     "prefix": "StripeSetupIntentRetrieve",
-    "body": "$stripe->setupIntents->retrieve(\n  '${1:seti_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->setupIntents->retrieve(\n  '${1:seti_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Retrieve Setup Intent"
   },
   "Update Setup Intent": {
     "prefix": "StripeSetupIntentUpdate",
-    "body": "$stripe->setupIntents->update(\n  '${1:seti_xxxxxxxxxxxxx}',\n  ['metadata' => ['user_id' => '${2:3435453}']]\n)",
+    "body": "\\$stripe->setupIntents->update(\n  '${1:seti_xxxxxxxxxxxxx}',\n  ['metadata' => ['user_id' => '${2:3435453}']]\n)",
     "description": "Update Setup Intent"
   },
   "Confirm Setup Intent": {
     "prefix": "StripeSetupIntentConfirm",
-    "body": "$stripe->setupIntents->confirm(\n  '${1:seti_xxxxxxxxxxxxx}',\n  ['payment_method' => '${2:pm_card_visa}']\n)",
+    "body": "\\$stripe->setupIntents->confirm(\n  '${1:seti_xxxxxxxxxxxxx}',\n  ['payment_method' => '${2:pm_card_visa}']\n)",
     "description": "Confirm Setup Intent"
   },
   "Cancel Setup Intent": {
     "prefix": "StripeSetupIntentCancel",
-    "body": "$stripe->setupIntents->cancel(\n  '${1:seti_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->setupIntents->cancel(\n  '${1:seti_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Cancel Setup Intent"
   },
   "List Setup Intent": {
     "prefix": "StripeSetupIntentList",
-    "body": "$stripe->setupIntents->all(['limit' => ${1:3}])",
+    "body": "\\$stripe->setupIntents->all(['limit' => ${1:3}])",
     "description": "List Setup Intent"
   },
   "List Setup Attempt": {
     "prefix": "StripeSetupAttemptList",
-    "body": "$stripe->setupAttempts->all(['limit' => ${1:3}])",
+    "body": "\\$stripe->setupAttempts->all(['limit' => ${1:3}])",
     "description": "List Setup Attempt"
   },
   "Create Payout": {
     "prefix": "StripePayoutCreate",
-    "body": "$stripe->payouts->create([\n  'amount' => ${1:1100},\n  'currency' => '${2:usd}',\n])",
+    "body": "\\$stripe->payouts->create([\n  'amount' => ${1:1100},\n  'currency' => '${2:usd}',\n])",
     "description": "Create Payout"
   },
   "Retrieve Payout": {
     "prefix": "StripePayoutRetrieve",
-    "body": "$stripe->payouts->retrieve('${1:po_xxxxxxxxxxxxx}', [])",
+    "body": "\\$stripe->payouts->retrieve('${1:po_xxxxxxxxxxxxx}', [])",
     "description": "Retrieve Payout"
   },
   "Update Payout": {
     "prefix": "StripePayoutUpdate",
-    "body": "$stripe->payouts->update(\n  '${1:po_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${2:6735}']]\n)",
+    "body": "\\$stripe->payouts->update(\n  '${1:po_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${2:6735}']]\n)",
     "description": "Update Payout"
   },
   "List Payout": {
     "prefix": "StripePayoutList",
-    "body": "$stripe->payouts->all(['limit' => ${1:3}])",
+    "body": "\\$stripe->payouts->all(['limit' => ${1:3}])",
     "description": "List Payout"
   },
   "Cancel Payout": {
     "prefix": "StripePayoutCancel",
-    "body": "$stripe->payouts->cancel('${1:po_xxxxxxxxxxxxx}', [])",
+    "body": "\\$stripe->payouts->cancel('${1:po_xxxxxxxxxxxxx}', [])",
     "description": "Cancel Payout"
   },
   "Reverse Payout": {
     "prefix": "StripePayoutReverse",
-    "body": "$stripe->payouts->reverse('${1:po_xxxxxxxxxxxxx}', [])",
+    "body": "\\$stripe->payouts->reverse('${1:po_xxxxxxxxxxxxx}', [])",
     "description": "Reverse Payout"
   },
   "Create Product": {
     "prefix": "StripeProductCreate",
-    "body": "$stripe->products->create([\n  'name' => '${1:Gold Special}',\n])",
+    "body": "\\$stripe->products->create([\n  'name' => '${1:Gold Special}',\n])",
     "description": "Create Product"
   },
   "Retrieve Product": {
     "prefix": "StripeProductRetrieve",
-    "body": "$stripe->products->retrieve(\n  '${1:prod_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->products->retrieve(\n  '${1:prod_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Retrieve Product"
   },
   "Update Product": {
     "prefix": "StripeProductUpdate",
-    "body": "$stripe->products->update(\n  '${1:prod_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${2:6735}']]\n)",
+    "body": "\\$stripe->products->update(\n  '${1:prod_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${2:6735}']]\n)",
     "description": "Update Product"
   },
   "List Product": {
     "prefix": "StripeProductList",
-    "body": "$stripe->products->all(['limit' => ${1:3}])",
+    "body": "\\$stripe->products->all(['limit' => ${1:3}])",
     "description": "List Product"
   },
   "Delete Product": {
     "prefix": "StripeProductDelete",
-    "body": "$stripe->products->delete(\n  '${1:prod_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->products->delete(\n  '${1:prod_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Delete Product"
   },
   "Create Price": {
     "prefix": "StripePriceCreate",
-    "body": "$stripe->prices->create([\n  'unit_amount' => ${1:2000},\n  'currency' => '${2:usd}',\n  'recurring' => ['interval' => '${3:month}'],\n  'product' => '${4:prod_xxxxxxxxxxxxx}',\n])",
+    "body": "\\$stripe->prices->create([\n  'unit_amount' => ${1:2000},\n  'currency' => '${2:usd}',\n  'recurring' => ['interval' => '${3:month}'],\n  'product' => '${4:prod_xxxxxxxxxxxxx}',\n])",
     "description": "Create Price"
   },
   "Retrieve Price": {
     "prefix": "StripePriceRetrieve",
-    "body": "$stripe->prices->retrieve(\n  '${1:price_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->prices->retrieve(\n  '${1:price_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Retrieve Price"
   },
   "Update Price": {
     "prefix": "StripePriceUpdate",
-    "body": "$stripe->prices->update(\n  '${1:price_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${2:6735}']]\n)",
+    "body": "\\$stripe->prices->update(\n  '${1:price_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${2:6735}']]\n)",
     "description": "Update Price"
   },
   "List Price": {
     "prefix": "StripePriceList",
-    "body": "$stripe->prices->all(['limit' => ${1:3}])",
+    "body": "\\$stripe->prices->all(['limit' => ${1:3}])",
     "description": "List Price"
   },
   "Create Refund": {
     "prefix": "StripeRefundCreate",
-    "body": "$stripe->refunds->create([\n  'charge' => '${1:ch_xxxxxxxxxxxxx}',\n])",
+    "body": "\\$stripe->refunds->create([\n  'charge' => '${1:ch_xxxxxxxxxxxxx}',\n])",
     "description": "Create Refund"
   },
   "Retrieve Refund": {
     "prefix": "StripeRefundRetrieve",
-    "body": "$stripe->refunds->retrieve('${1:re_xxxxxxxxxxxxx}', [])",
+    "body": "\\$stripe->refunds->retrieve('${1:re_xxxxxxxxxxxxx}', [])",
     "description": "Retrieve Refund"
   },
   "Update Refund": {
     "prefix": "StripeRefundUpdate",
-    "body": "$stripe->refunds->update(\n  '${1:re_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${2:6735}']]\n)",
+    "body": "\\$stripe->refunds->update(\n  '${1:re_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${2:6735}']]\n)",
     "description": "Update Refund"
   },
   "List Refund": {
     "prefix": "StripeRefundList",
-    "body": "$stripe->refunds->all(['limit' => ${1:3}])",
+    "body": "\\$stripe->refunds->all(['limit' => ${1:3}])",
     "description": "List Refund"
   },
   "Create Token": {
     "prefix": "StripeTokenCreate",
-    "body": "$stripe->tokens->create([\n  'cvc_update' => ['cvc' => '${1:123}'],\n])",
+    "body": "\\$stripe->tokens->create([\n  'cvc_update' => ['cvc' => '${1:123}'],\n])",
     "description": "Create Token"
   },
   "Retrieve Token": {
     "prefix": "StripeTokenRetrieve",
-    "body": "$stripe->tokens->retrieve('${1:tok_xxxx}', [])",
+    "body": "\\$stripe->tokens->retrieve('${1:tok_xxxx}', [])",
     "description": "Retrieve Token"
   },
   "Create Payment Method": {
     "prefix": "StripePaymentMethodCreate",
-    "body": "$stripe->paymentMethods->create([\n  'type' => '${1:card}',\n  'card' => [\n    'number' => '${2:4242424242424242}',\n    'exp_month' => ${3:11},\n    'exp_year' => ${4:2021},\n    'cvc' => '${5:314}',\n  ],\n])",
+    "body": "\\$stripe->paymentMethods->create([\n  'type' => '${1:card}',\n  'card' => [\n    'number' => '${2:4242424242424242}',\n    'exp_month' => ${3:11},\n    'exp_year' => ${4:2021},\n    'cvc' => '${5:314}',\n  ],\n])",
     "description": "Create Payment Method"
   },
   "Retrieve Payment Method": {
     "prefix": "StripePaymentMethodRetrieve",
-    "body": "$stripe->paymentMethods->retrieve(\n  '${1:pm_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->paymentMethods->retrieve(\n  '${1:pm_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Retrieve Payment Method"
   },
   "Update Payment Method": {
     "prefix": "StripePaymentMethodUpdate",
-    "body": "$stripe->paymentMethods->update(\n  '${1:pm_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${2:6735}']]\n)",
+    "body": "\\$stripe->paymentMethods->update(\n  '${1:pm_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${2:6735}']]\n)",
     "description": "Update Payment Method"
   },
   "List Payment Method": {
     "prefix": "StripePaymentMethodList",
-    "body": "$stripe->paymentMethods->all([\n  'customer' => '${1:cus_xxxxxxxxxxxxx}',\n  'type' => '${2:card}',\n])",
+    "body": "\\$stripe->paymentMethods->all([\n  'customer' => '${1:cus_xxxxxxxxxxxxx}',\n  'type' => '${2:card}',\n])",
     "description": "List Payment Method"
   },
   "Attach Payment Method": {
     "prefix": "StripePaymentMethodAttach",
-    "body": "$stripe->paymentMethods->attach(\n  '${1:pm_xxxxxxxxxxxxx}',\n  ['customer' => '${2:cus_xxxxxxxxxxxxx}']\n)",
+    "body": "\\$stripe->paymentMethods->attach(\n  '${1:pm_xxxxxxxxxxxxx}',\n  ['customer' => '${2:cus_xxxxxxxxxxxxx}']\n)",
     "description": "Attach Payment Method"
   },
   "Detach Payment Method": {
     "prefix": "StripePaymentMethodDetach",
-    "body": "$stripe->paymentMethods->detach(\n  '${1:pm_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->paymentMethods->detach(\n  '${1:pm_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Detach Payment Method"
   },
   "Create Customer Bank Account": {
     "prefix": "StripeCustomerBankAccountCreate",
-    "body": "$stripe->customers->createSource(\n  '${1:cus_xxxxxxxxxxxxx}',\n  ['source' => '${2:btok_xxxxxxxxxxxxx}']\n)",
+    "body": "\\$stripe->customers->createSource(\n  '${1:cus_xxxxxxxxxxxxx}',\n  ['source' => '${2:btok_xxxxxxxxxxxxx}']\n)",
     "description": "Create Customer Bank Account"
   },
   "Retrieve Customer Bank Account": {
     "prefix": "StripeCustomerBankAccountRetrieve",
-    "body": "$stripe->customers->retrieveSource(\n  '${2:cus_xxxxxxxxxxxxx}',\n  '${1:ba_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->customers->retrieveSource(\n  '${2:cus_xxxxxxxxxxxxx}',\n  '${1:ba_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Retrieve Customer Bank Account"
   },
   "Update Customer Bank Account": {
     "prefix": "StripeCustomerBankAccountUpdate",
-    "body": "$stripe->customers->updateSource(\n  '${2:cus_xxxxxxxxxxxxx}',\n  '${1:ba_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${3:6735}']]\n)",
+    "body": "\\$stripe->customers->updateSource(\n  '${2:cus_xxxxxxxxxxxxx}',\n  '${1:ba_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${3:6735}']]\n)",
     "description": "Update Customer Bank Account"
   },
   "Verify Customer Bank Account": {
     "prefix": "StripeCustomerBankAccountVerify",
-    "body": "$stripe->customers->verifySource(\n  '${2:cus_xxxxxxxxxxxxx}',\n  '${1:ba_xxxxxxxxxxxxx}',\n  ['amounts' => [${3:32}, ${4:45}]]\n)",
+    "body": "\\$stripe->customers->verifySource(\n  '${2:cus_xxxxxxxxxxxxx}',\n  '${1:ba_xxxxxxxxxxxxx}',\n  ['amounts' => [${3:32}, ${4:45}]]\n)",
     "description": "Verify Customer Bank Account"
   },
   "Delete Customer Bank Account": {
     "prefix": "StripeCustomerBankAccountDelete",
-    "body": "$stripe->customers->deleteSource(\n  '${2:cus_xxxxxxxxxxxxx}',\n  '${1:ba_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->customers->deleteSource(\n  '${2:cus_xxxxxxxxxxxxx}',\n  '${1:ba_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Delete Customer Bank Account"
   },
   "List Customer Bank Account": {
     "prefix": "StripeCustomerBankAccountList",
-    "body": "$stripe->customers->allSources(\n  '${1:cus_xxxxxxxxxxxxx}',\n  ['object' => '${2:bank_account}', 'limit' => ${3:3}]\n)",
+    "body": "\\$stripe->customers->allSources(\n  '${1:cus_xxxxxxxxxxxxx}',\n  ['object' => '${2:bank_account}', 'limit' => ${3:3}]\n)",
     "description": "List Customer Bank Account"
   },
   "Create Customer Card": {
     "prefix": "StripeCustomerCardCreate",
-    "body": "$stripe->customers->createSource(\n  '${1:cus_xxxxxxxxxxxxx}',\n  ['source' => '${2:tok_xxxx}']\n)",
+    "body": "\\$stripe->customers->createSource(\n  '${1:cus_xxxxxxxxxxxxx}',\n  ['source' => '${2:tok_xxxx}']\n)",
     "description": "Create Customer Card"
   },
   "Retrieve Customer Card": {
     "prefix": "StripeCustomerCardRetrieve",
-    "body": "$stripe->customers->retrieveSource(\n  '${2:cus_xxxxxxxxxxxxx}',\n  '${1:card_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->customers->retrieveSource(\n  '${2:cus_xxxxxxxxxxxxx}',\n  '${1:card_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Retrieve Customer Card"
   },
   "Update Customer Card": {
     "prefix": "StripeCustomerCardUpdate",
-    "body": "$stripe->customers->updateSource(\n  '${2:cus_xxxxxxxxxxxxx}',\n  '${1:card_xxxxxxxxxxxxx}',\n  ['name' => '${3:Jenny Rosen}']\n)",
+    "body": "\\$stripe->customers->updateSource(\n  '${2:cus_xxxxxxxxxxxxx}',\n  '${1:card_xxxxxxxxxxxxx}',\n  ['name' => '${3:Jenny Rosen}']\n)",
     "description": "Update Customer Card"
   },
   "Delete Customer Card": {
     "prefix": "StripeCustomerCardDelete",
-    "body": "$stripe->customers->deleteSource(\n  '${2:cus_xxxxxxxxxxxxx}',\n  '${1:card_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->customers->deleteSource(\n  '${2:cus_xxxxxxxxxxxxx}',\n  '${1:card_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Delete Customer Card"
   },
   "List Customer Card": {
     "prefix": "StripeCustomerCardList",
-    "body": "$stripe->customers->allSources(\n  '${1:cus_xxxxxxxxxxxxx}',\n  ['object' => '${2:card}', 'limit' => ${3:3}]\n)",
+    "body": "\\$stripe->customers->allSources(\n  '${1:cus_xxxxxxxxxxxxx}',\n  ['object' => '${2:card}', 'limit' => ${3:3}]\n)",
     "description": "List Customer Card"
   },
   "Retrieve Source": {
     "prefix": "StripeSourceRetrieve",
-    "body": "$stripe->sources->retrieve(\n  '${1:src_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->sources->retrieve(\n  '${1:src_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Retrieve Source"
   },
   "Update Source": {
     "prefix": "StripeSourceUpdate",
-    "body": "$stripe->sources->update(\n  '${1:src_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${2:6735}']]\n)",
+    "body": "\\$stripe->sources->update(\n  '${1:src_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${2:6735}']]\n)",
     "description": "Update Source"
   },
   "Create Checkout Session": {
     "prefix": "StripeCheckoutSessionCreate",
-    "body": "$stripe->checkout->sessions->create([\n  'success_url' => '${1:https://example.com/success}',\n  'cancel_url' => '${2:https://example.com/cancel}',\n  'payment_method_types' => ['${3:card}'],\n  'line_items' => [\n    [\n      'price' => '${4:price_xxxxxxxxxxxxx}',\n      'quantity' => ${5:2},\n    ],\n  ],\n  'mode' => '${6:payment}',\n])",
+    "body": "\\$stripe->checkout->sessions->create([\n  'success_url' => '${1:https://example.com/success}',\n  'cancel_url' => '${2:https://example.com/cancel}',\n  'payment_method_types' => ['${3:card}'],\n  'line_items' => [\n    [\n      'price' => '${4:price_xxxxxxxxxxxxx}',\n      'quantity' => ${5:2},\n    ],\n  ],\n  'mode' => '${6:payment}',\n])",
     "description": "Create Checkout Session"
   },
   "Retrieve Checkout Session": {
     "prefix": "StripeCheckoutSessionRetrieve",
-    "body": "$stripe->checkout->sessions->retrieve(\n  '${1:cs_test_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->checkout->sessions->retrieve(\n  '${1:cs_test_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Retrieve Checkout Session"
   },
   "List Checkout Session": {
     "prefix": "StripeCheckoutSessionList",
-    "body": "$stripe->checkout->sessions->all(['limit' => ${1:3}])",
+    "body": "\\$stripe->checkout->sessions->all(['limit' => ${1:3}])",
     "description": "List Checkout Session"
   },
   "Create Coupon": {
     "prefix": "StripeCouponCreate",
-    "body": "$stripe->coupons->create([\n  'percent_off' => ${1:25},\n  'duration' => '${2:repeating}',\n  'duration_in_months' => ${3:3},\n])",
+    "body": "\\$stripe->coupons->create([\n  'percent_off' => ${1:25},\n  'duration' => '${2:repeating}',\n  'duration_in_months' => ${3:3},\n])",
     "description": "Create Coupon"
   },
   "Retrieve Coupon": {
     "prefix": "StripeCouponRetrieve",
-    "body": "$stripe->coupons->retrieve('${1:25_5OFF}', [])",
+    "body": "\\$stripe->coupons->retrieve('${1:25_5OFF}', [])",
     "description": "Retrieve Coupon"
   },
   "Update Coupon": {
     "prefix": "StripeCouponUpdate",
-    "body": "$stripe->coupons->update(\n  '${1:co_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${2:6735}']]\n)",
+    "body": "\\$stripe->coupons->update(\n  '${1:co_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${2:6735}']]\n)",
     "description": "Update Coupon"
   },
   "Delete Coupon": {
     "prefix": "StripeCouponDelete",
-    "body": "$stripe->coupons->delete('${1:co_xxxxxxxxxxxxx}', [])",
+    "body": "\\$stripe->coupons->delete('${1:co_xxxxxxxxxxxxx}', [])",
     "description": "Delete Coupon"
   },
   "List Coupon": {
     "prefix": "StripeCouponList",
-    "body": "$stripe->coupons->all(['limit' => ${1:3}])",
+    "body": "\\$stripe->coupons->all(['limit' => ${1:3}])",
     "description": "List Coupon"
   },
   "Preview Credit Note": {
     "prefix": "StripeCreditNotePreview",
-    "body": "$stripe->creditNotes->preview([\n  'invoice' => '${1:in_xxxxxxxxxxxxx}',\n  'lines' => [\n    [\n      'type' => '${2:invoice_line_item}',\n      'invoice_line_item' => '${3:il_xxxxxxxxxxxxx}',\n      'quantity' => ${4:1},\n    ],\n  ],\n])",
+    "body": "\\$stripe->creditNotes->preview([\n  'invoice' => '${1:in_xxxxxxxxxxxxx}',\n  'lines' => [\n    [\n      'type' => '${2:invoice_line_item}',\n      'invoice_line_item' => '${3:il_xxxxxxxxxxxxx}',\n      'quantity' => ${4:1},\n    ],\n  ],\n])",
     "description": "Preview Credit Note"
   },
   "Create Credit Note": {
     "prefix": "StripeCreditNoteCreate",
-    "body": "$stripe->creditNotes->create([\n  'invoice' => '${1:in_xxxxxxxxxxxxx}',\n  'lines' => [\n    [\n      'type' => '${2:invoice_line_item}',\n      'invoice_line_item' => '${3:il_xxxxxxxxxxxxx}',\n      'quantity' => ${4:1},\n    ],\n  ],\n])",
+    "body": "\\$stripe->creditNotes->create([\n  'invoice' => '${1:in_xxxxxxxxxxxxx}',\n  'lines' => [\n    [\n      'type' => '${2:invoice_line_item}',\n      'invoice_line_item' => '${3:il_xxxxxxxxxxxxx}',\n      'quantity' => ${4:1},\n    ],\n  ],\n])",
     "description": "Create Credit Note"
   },
   "Retrieve Credit Note": {
     "prefix": "StripeCreditNoteRetrieve",
-    "body": "$stripe->creditNotes->retrieve(\n  '${1:cn_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->creditNotes->retrieve(\n  '${1:cn_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Retrieve Credit Note"
   },
   "Update Credit Note": {
     "prefix": "StripeCreditNoteUpdate",
-    "body": "$stripe->creditNotes->update(\n  '${1:cn_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${2:6735}']]\n)",
+    "body": "\\$stripe->creditNotes->update(\n  '${1:cn_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${2:6735}']]\n)",
     "description": "Update Credit Note"
   },
   "List Credit Note Line Item": {
     "prefix": "StripeCreditNoteLineItemList",
-    "body": "$stripe->creditNotes->allLines(\n  '${1:cn_xxxxxxxxxxxxx}',\n  ['limit' => ${2:3}]\n)",
+    "body": "\\$stripe->creditNotes->allLines(\n  '${1:cn_xxxxxxxxxxxxx}',\n  ['limit' => ${2:3}]\n)",
     "description": "List Credit Note Line Item"
   },
   "List Credit Note Credit Note Line Item": {
     "prefix": "StripeCreditNoteCreditNoteLineItemList",
-    "body": "$stripe->creditNotes->allCreditNoteLineItems([\n  'invoice' => '${1:in_xxxxxxxxxxxxx}',\n  'lines' => [\n    [\n      'type' => '${2:invoice_line_item}',\n      'invoice_line_item' => '${3:il_xxxxxxxxxxxxx}',\n      'quantity' => ${4:1},\n    ],\n  ],\n])",
+    "body": "\\$stripe->creditNotes->allCreditNoteLineItems([\n  'invoice' => '${1:in_xxxxxxxxxxxxx}',\n  'lines' => [\n    [\n      'type' => '${2:invoice_line_item}',\n      'invoice_line_item' => '${3:il_xxxxxxxxxxxxx}',\n      'quantity' => ${4:1},\n    ],\n  ],\n])",
     "description": "List Credit Note Credit Note Line Item"
   },
   "Void Credit Note Credit Note": {
     "prefix": "StripeCreditNoteVoidCreditNote",
-    "body": "$stripe->creditNotes->voidCreditNote(\n  '${1:cn_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->creditNotes->voidCreditNote(\n  '${1:cn_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Void Credit Note Credit Note"
   },
   "List Credit Note": {
     "prefix": "StripeCreditNoteList",
-    "body": "$stripe->creditNotes->all(['limit' => ${1:3}])",
+    "body": "\\$stripe->creditNotes->all(['limit' => ${1:3}])",
     "description": "List Credit Note"
   },
   "Create Customer Balance Transaction": {
     "prefix": "StripeCustomerBalanceTransactionCreate",
-    "body": "$stripe->customers->createBalanceTransaction(\n  '${1:cus_xxxxxxxxxxxxx}',\n  ['amount' => ${2:-500}, 'currency' => '${3:usd}']\n)",
+    "body": "\\$stripe->customers->createBalanceTransaction(\n  '${1:cus_xxxxxxxxxxxxx}',\n  ['amount' => ${2:-500}, 'currency' => '${3:usd}']\n)",
     "description": "Create Customer Balance Transaction"
   },
   "Retrieve Customer Balance Transaction": {
     "prefix": "StripeCustomerBalanceTransactionRetrieve",
-    "body": "$stripe->customers->retrieveBalanceTransaction(\n  '${2:cus_xxxxxxxxxxxxx}',\n  '${1:cbtxn_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->customers->retrieveBalanceTransaction(\n  '${2:cus_xxxxxxxxxxxxx}',\n  '${1:cbtxn_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Retrieve Customer Balance Transaction"
   },
   "Update Customer Balance Transaction": {
     "prefix": "StripeCustomerBalanceTransactionUpdate",
-    "body": "$stripe->customers->updateBalanceTransaction(\n  '${2:cus_xxxxxxxxxxxxx}',\n  '${1:cbtxn_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${3:6735}']]\n)",
+    "body": "\\$stripe->customers->updateBalanceTransaction(\n  '${2:cus_xxxxxxxxxxxxx}',\n  '${1:cbtxn_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${3:6735}']]\n)",
     "description": "Update Customer Balance Transaction"
   },
   "List Customer Balance Transaction": {
     "prefix": "StripeCustomerBalanceTransactionList",
-    "body": "$stripe->customers->allBalanceTransactions(\n  '${1:cus_xxxxxxxxxxxxx}',\n  ['limit' => ${2:3}]\n)",
+    "body": "\\$stripe->customers->allBalanceTransactions(\n  '${1:cus_xxxxxxxxxxxxx}',\n  ['limit' => ${2:3}]\n)",
     "description": "List Customer Balance Transaction"
   },
   "Create Billing Portal Session": {
     "prefix": "StripeBillingPortalSessionCreate",
-    "body": "$stripe->billingPortal->sessions->create([\n  'customer' => '${1:cus_xxxxxxxxxxxxx}',\n  'return_url' => '${2:https://example.com/account}',\n])",
+    "body": "\\$stripe->billingPortal->sessions->create([\n  'customer' => '${1:cus_xxxxxxxxxxxxx}',\n  'return_url' => '${2:https://example.com/account}',\n])",
     "description": "Create Billing Portal Session"
   },
   "Create Customer Tax Id": {
     "prefix": "StripeCustomerTaxIdCreate",
-    "body": "$stripe->customers->createTaxId(\n  '${1:cus_xxxxxxxxxxxxx}',\n  ['type' => '${2:eu_vat}', 'value' => '${3:DE123456789}']\n)",
+    "body": "\\$stripe->customers->createTaxId(\n  '${1:cus_xxxxxxxxxxxxx}',\n  ['type' => '${2:eu_vat}', 'value' => '${3:DE123456789}']\n)",
     "description": "Create Customer Tax Id"
   },
   "Retrieve Customer Tax Id": {
     "prefix": "StripeCustomerTaxIdRetrieve",
-    "body": "$stripe->customers->retrieveTaxId(\n  '${2:cus_xxxxxxxxxxxxx}',\n  '${1:txi_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->customers->retrieveTaxId(\n  '${2:cus_xxxxxxxxxxxxx}',\n  '${1:txi_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Retrieve Customer Tax Id"
   },
   "Delete Customer Tax Id": {
     "prefix": "StripeCustomerTaxIdDelete",
-    "body": "$stripe->customers->deleteTaxId(\n  '${2:cus_xxxxxxxxxxxxx}',\n  '${1:txi_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->customers->deleteTaxId(\n  '${2:cus_xxxxxxxxxxxxx}',\n  '${1:txi_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Delete Customer Tax Id"
   },
   "List Customer Tax Id": {
     "prefix": "StripeCustomerTaxIdList",
-    "body": "$stripe->customers->allTaxIds(\n  '${1:cus_xxxxxxxxxxxxx}',\n  ['limit' => ${2:3}]\n)",
+    "body": "\\$stripe->customers->allTaxIds(\n  '${1:cus_xxxxxxxxxxxxx}',\n  ['limit' => ${2:3}]\n)",
     "description": "List Customer Tax Id"
   },
   "Create Invoice": {
     "prefix": "StripeInvoiceCreate",
-    "body": "$stripe->invoices->create([\n  'customer' => '${1:cus_xxxxxxxxxxxxx}',\n])",
+    "body": "\\$stripe->invoices->create([\n  'customer' => '${1:cus_xxxxxxxxxxxxx}',\n])",
     "description": "Create Invoice"
   },
   "Retrieve Invoice": {
     "prefix": "StripeInvoiceRetrieve",
-    "body": "$stripe->invoices->retrieve(\n  '${1:in_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->invoices->retrieve(\n  '${1:in_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Retrieve Invoice"
   },
   "Update Invoice": {
     "prefix": "StripeInvoiceUpdate",
-    "body": "$stripe->invoices->update(\n  '${1:in_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${2:6735}']]\n)",
+    "body": "\\$stripe->invoices->update(\n  '${1:in_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${2:6735}']]\n)",
     "description": "Update Invoice"
   },
   "Delete Invoice": {
     "prefix": "StripeInvoiceDelete",
-    "body": "$stripe->invoices->delete('${1:in_xxxxxxxxxxxxx}', [])",
+    "body": "\\$stripe->invoices->delete('${1:in_xxxxxxxxxxxxx}', [])",
     "description": "Delete Invoice"
   },
   "Finalize Invoice Invoice": {
     "prefix": "StripeInvoiceFinalizeInvoice",
-    "body": "$stripe->invoices->finalizeInvoice(\n  '${1:in_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->invoices->finalizeInvoice(\n  '${1:in_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Finalize Invoice Invoice"
   },
   "Pay Invoice": {
     "prefix": "StripeInvoicePay",
-    "body": "$stripe->invoices->pay('${1:in_xxxxxxxxxxxxx}', [])",
+    "body": "\\$stripe->invoices->pay('${1:in_xxxxxxxxxxxxx}', [])",
     "description": "Pay Invoice"
   },
   "Send Invoice Invoice": {
     "prefix": "StripeInvoiceSendInvoice",
-    "body": "$stripe->invoices->sendInvoice(\n  '${1:in_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->invoices->sendInvoice(\n  '${1:in_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Send Invoice Invoice"
   },
   "Void Invoice Invoice": {
     "prefix": "StripeInvoiceVoidInvoice",
-    "body": "$stripe->invoices->voidInvoice(\n  '${1:in_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->invoices->voidInvoice(\n  '${1:in_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Void Invoice Invoice"
   },
   "Mark Uncollectible Invoice": {
     "prefix": "StripeInvoiceMarkUncollectible",
-    "body": "$stripe->invoices->markUncollectible(\n  '${1:in_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->invoices->markUncollectible(\n  '${1:in_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Mark Uncollectible Invoice"
   },
   "List Invoice": {
     "prefix": "StripeInvoiceList",
-    "body": "$stripe->invoices->all(['limit' => ${1:3}])",
+    "body": "\\$stripe->invoices->all(['limit' => ${1:3}])",
     "description": "List Invoice"
   },
   "Create Invoice Item": {
     "prefix": "StripeInvoiceItemCreate",
-    "body": "$stripe->invoiceItems->create([\n  'customer' => '${1:cus_xxxxxxxxxxxxx}',\n  'price' => '${2:price_xxxxxxxxxxxxx}',\n])",
+    "body": "\\$stripe->invoiceItems->create([\n  'customer' => '${1:cus_xxxxxxxxxxxxx}',\n  'price' => '${2:price_xxxxxxxxxxxxx}',\n])",
     "description": "Create Invoice Item"
   },
   "Retrieve Invoice Item": {
     "prefix": "StripeInvoiceItemRetrieve",
-    "body": "$stripe->invoiceItems->retrieve(\n  '${1:ii_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->invoiceItems->retrieve(\n  '${1:ii_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Retrieve Invoice Item"
   },
   "Update Invoice Item": {
     "prefix": "StripeInvoiceItemUpdate",
-    "body": "$stripe->invoiceItems->update(\n  '${1:ii_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${2:6735}']]\n)",
+    "body": "\\$stripe->invoiceItems->update(\n  '${1:ii_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${2:6735}']]\n)",
     "description": "Update Invoice Item"
   },
   "Delete Invoice Item": {
     "prefix": "StripeInvoiceItemDelete",
-    "body": "$stripe->invoiceItems->delete(\n  '${1:ii_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->invoiceItems->delete(\n  '${1:ii_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Delete Invoice Item"
   },
   "List Invoice Item": {
     "prefix": "StripeInvoiceItemList",
-    "body": "$stripe->invoiceItems->all(['limit' => ${1:3}])",
+    "body": "\\$stripe->invoiceItems->all(['limit' => ${1:3}])",
     "description": "List Invoice Item"
   },
   "Create Plan": {
     "prefix": "StripePlanCreate",
-    "body": "$stripe->plans->create([\n  'amount' => ${1:2000},\n  'currency' => '${2:usd}',\n  'interval' => '${3:month}',\n  'product' => '${4:prod_xxxxxxxxxxxxx}',\n])",
+    "body": "\\$stripe->plans->create([\n  'amount' => ${1:2000},\n  'currency' => '${2:usd}',\n  'interval' => '${3:month}',\n  'product' => '${4:prod_xxxxxxxxxxxxx}',\n])",
     "description": "Create Plan"
   },
   "Retrieve Plan": {
     "prefix": "StripePlanRetrieve",
-    "body": "$stripe->plans->retrieve(\n  '${1:price_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->plans->retrieve(\n  '${1:price_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Retrieve Plan"
   },
   "Update Plan": {
     "prefix": "StripePlanUpdate",
-    "body": "$stripe->plans->update(\n  '${1:price_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${2:6735}']]\n)",
+    "body": "\\$stripe->plans->update(\n  '${1:price_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${2:6735}']]\n)",
     "description": "Update Plan"
   },
   "Delete Plan": {
     "prefix": "StripePlanDelete",
-    "body": "$stripe->plans->delete('${1:price_xxxxxxxxxxxxx}', [])",
+    "body": "\\$stripe->plans->delete('${1:price_xxxxxxxxxxxxx}', [])",
     "description": "Delete Plan"
   },
   "List Plan": {
     "prefix": "StripePlanList",
-    "body": "$stripe->plans->all(['limit' => ${1:3}])",
+    "body": "\\$stripe->plans->all(['limit' => ${1:3}])",
     "description": "List Plan"
   },
   "Create Promotion Code": {
     "prefix": "StripePromotionCodeCreate",
-    "body": "$stripe->promotionCodes->create([\n  'coupon' => '${1:25_5OFF}',\n])",
+    "body": "\\$stripe->promotionCodes->create([\n  'coupon' => '${1:25_5OFF}',\n])",
     "description": "Create Promotion Code"
   },
   "Update Promotion Code": {
     "prefix": "StripePromotionCodeUpdate",
-    "body": "$stripe->promotionCodes->update(\n  '${1:promo_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${2:6735}']]\n)",
+    "body": "\\$stripe->promotionCodes->update(\n  '${1:promo_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${2:6735}']]\n)",
     "description": "Update Promotion Code"
   },
   "Retrieve Promotion Code": {
     "prefix": "StripePromotionCodeRetrieve",
-    "body": "$stripe->promotionCodes->retrieve(\n  '${1:promo_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->promotionCodes->retrieve(\n  '${1:promo_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Retrieve Promotion Code"
   },
   "List Promotion Code": {
     "prefix": "StripePromotionCodeList",
-    "body": "$stripe->promotionCodes->all(['limit' => ${1:3}])",
+    "body": "\\$stripe->promotionCodes->all(['limit' => ${1:3}])",
     "description": "List Promotion Code"
   },
   "Create Subscription": {
     "prefix": "StripeSubscriptionCreate",
-    "body": "$stripe->subscriptions->create([\n  'customer' => '${1:cus_xxxxxxxxxxxxx}',\n  'items' => [['price' => '${2:price_xxxxxxxxxxxxx}']],\n])",
+    "body": "\\$stripe->subscriptions->create([\n  'customer' => '${1:cus_xxxxxxxxxxxxx}',\n  'items' => [['price' => '${2:price_xxxxxxxxxxxxx}']],\n])",
     "description": "Create Subscription"
   },
   "Retrieve Subscription": {
     "prefix": "StripeSubscriptionRetrieve",
-    "body": "$stripe->subscriptions->retrieve(\n  '${1:sub_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->subscriptions->retrieve(\n  '${1:sub_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Retrieve Subscription"
   },
   "Update Subscription": {
     "prefix": "StripeSubscriptionUpdate",
-    "body": "$stripe->subscriptions->update(\n  '${1:sub_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${2:6735}']]\n)",
+    "body": "\\$stripe->subscriptions->update(\n  '${1:sub_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${2:6735}']]\n)",
     "description": "Update Subscription"
   },
   "Delete Subscription": {
     "prefix": "StripeSubscriptionDelete",
-    "body": "$stripe->subscriptions->cancel(\n  '${1:sub_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->subscriptions->cancel(\n  '${1:sub_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Delete Subscription"
   },
   "List Subscription": {
     "prefix": "StripeSubscriptionList",
-    "body": "$stripe->subscriptions->all(['limit' => ${1:3}])",
+    "body": "\\$stripe->subscriptions->all(['limit' => ${1:3}])",
     "description": "List Subscription"
   },
   "Create Subscription Item": {
     "prefix": "StripeSubscriptionItemCreate",
-    "body": "$stripe->subscriptionItems->create([\n  'subscription' => '${1:sub_xxxxxxxxxxxxx}',\n  'price' => '${2:price_xxxxxxxxxxxxx}',\n  'quantity' => ${3:2},\n])",
+    "body": "\\$stripe->subscriptionItems->create([\n  'subscription' => '${1:sub_xxxxxxxxxxxxx}',\n  'price' => '${2:price_xxxxxxxxxxxxx}',\n  'quantity' => ${3:2},\n])",
     "description": "Create Subscription Item"
   },
   "Retrieve Subscription Item": {
     "prefix": "StripeSubscriptionItemRetrieve",
-    "body": "$stripe->subscriptionItems->retrieve(\n  '${1:si_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->subscriptionItems->retrieve(\n  '${1:si_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Retrieve Subscription Item"
   },
   "Update Subscription Item": {
     "prefix": "StripeSubscriptionItemUpdate",
-    "body": "$stripe->subscriptionItems->update(\n  '${1:si_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${2:6735}']]\n)",
+    "body": "\\$stripe->subscriptionItems->update(\n  '${1:si_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${2:6735}']]\n)",
     "description": "Update Subscription Item"
   },
   "Delete Subscription Item": {
     "prefix": "StripeSubscriptionItemDelete",
-    "body": "$stripe->subscriptionItems->delete(\n  '${1:si_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->subscriptionItems->delete(\n  '${1:si_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Delete Subscription Item"
   },
   "List Subscription Item": {
     "prefix": "StripeSubscriptionItemList",
-    "body": "$stripe->subscriptionItems->all([\n  'subscription' => '${1:sub_xxxxxxxxxxxxx}',\n])",
+    "body": "\\$stripe->subscriptionItems->all([\n  'subscription' => '${1:sub_xxxxxxxxxxxxx}',\n])",
     "description": "List Subscription Item"
   },
   "Create Subscription Schedule": {
     "prefix": "StripeSubscriptionScheduleCreate",
-    "body": "$stripe->subscriptionSchedules->create([\n  'customer' => '${1:cus_xxxxxxxxxxxxx}',\n  'start_date' => ${2:1605558431},\n  'end_behavior' => '${3:release}',\n  'phases' => [\n    [\n      'items' => [\n        [\n          'price' => '${4:price_xxxxxxxxxxxxx}',\n          'quantity' => ${5:1},\n        ],\n      ],\n      'iterations' => ${6:12},\n    ],\n  ],\n])",
+    "body": "\\$stripe->subscriptionSchedules->create([\n  'customer' => '${1:cus_xxxxxxxxxxxxx}',\n  'start_date' => ${2:1605558431},\n  'end_behavior' => '${3:release}',\n  'phases' => [\n    [\n      'items' => [\n        [\n          'price' => '${4:price_xxxxxxxxxxxxx}',\n          'quantity' => ${5:1},\n        ],\n      ],\n      'iterations' => ${6:12},\n    ],\n  ],\n])",
     "description": "Create Subscription Schedule"
   },
   "Retrieve Subscription Schedule": {
     "prefix": "StripeSubscriptionScheduleRetrieve",
-    "body": "$stripe->subscriptionSchedules->retrieve(\n  '${1:sub_sched_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->subscriptionSchedules->retrieve(\n  '${1:sub_sched_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Retrieve Subscription Schedule"
   },
   "Update Subscription Schedule": {
     "prefix": "StripeSubscriptionScheduleUpdate",
-    "body": "$stripe->subscriptionSchedules->update(\n  '${1:sub_sched_xxxxxxxxxxxxx}',\n  ['end_behavior' => '${2:release}']\n)",
+    "body": "\\$stripe->subscriptionSchedules->update(\n  '${1:sub_sched_xxxxxxxxxxxxx}',\n  ['end_behavior' => '${2:release}']\n)",
     "description": "Update Subscription Schedule"
   },
   "Cancel Subscription Schedule": {
     "prefix": "StripeSubscriptionScheduleCancel",
-    "body": "$stripe->subscriptionSchedules->cancel(\n  '${1:sub_sched_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->subscriptionSchedules->cancel(\n  '${1:sub_sched_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Cancel Subscription Schedule"
   },
   "Release Subscription Schedule": {
     "prefix": "StripeSubscriptionScheduleRelease",
-    "body": "$stripe->subscriptionSchedules->release(\n  '${1:sub_sched_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->subscriptionSchedules->release(\n  '${1:sub_sched_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Release Subscription Schedule"
   },
   "List Subscription Schedule": {
     "prefix": "StripeSubscriptionScheduleList",
-    "body": "$stripe->subscriptionSchedules->all([\n  'limit' => ${1:3},\n])",
+    "body": "\\$stripe->subscriptionSchedules->all([\n  'limit' => ${1:3},\n])",
     "description": "List Subscription Schedule"
   },
   "Create Tax Rate": {
     "prefix": "StripeTaxRateCreate",
-    "body": "$stripe->taxRates->create([\n  'display_name' => '${1:VAT}',\n  'description' => '${2:VAT Germany}',\n  'jurisdiction' => '${3:DE}',\n  'percentage' => ${4:16},\n  'inclusive' => ${5:false},\n])",
+    "body": "\\$stripe->taxRates->create([\n  'display_name' => '${1:VAT}',\n  'description' => '${2:VAT Germany}',\n  'jurisdiction' => '${3:DE}',\n  'percentage' => ${4:16},\n  'inclusive' => ${5:false},\n])",
     "description": "Create Tax Rate"
   },
   "Retrieve Tax Rate": {
     "prefix": "StripeTaxRateRetrieve",
-    "body": "$stripe->taxRates->retrieve(\n  '${1:txr_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->taxRates->retrieve(\n  '${1:txr_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Retrieve Tax Rate"
   },
   "Update Tax Rate": {
     "prefix": "StripeTaxRateUpdate",
-    "body": "$stripe->taxRates->update(\n  '${1:txr_xxxxxxxxxxxxx}',\n  ['active' => ${2:false}]\n)",
+    "body": "\\$stripe->taxRates->update(\n  '${1:txr_xxxxxxxxxxxxx}',\n  ['active' => ${2:false}]\n)",
     "description": "Update Tax Rate"
   },
   "List Tax Rate": {
     "prefix": "StripeTaxRateList",
-    "body": "$stripe->taxRates->all(['limit' => ${1:3}])",
+    "body": "\\$stripe->taxRates->all(['limit' => ${1:3}])",
     "description": "List Tax Rate"
   },
   "Create Subscription Item Usage Record": {
     "prefix": "StripeSubscriptionItemUsageRecordCreate",
-    "body": "$stripe->subscriptionItems->createUsageRecord(\n  '${1:si_xxxxxxxxxxxxx}',\n  ['quantity' => ${2:100}, 'timestamp' => ${3:1571252444}]\n)",
+    "body": "\\$stripe->subscriptionItems->createUsageRecord(\n  '${1:si_xxxxxxxxxxxxx}',\n  ['quantity' => ${2:100}, 'timestamp' => ${3:1571252444}]\n)",
     "description": "Create Subscription Item Usage Record"
   },
   "List Subscription Item Usage Record Summary": {
     "prefix": "StripeSubscriptionItemUsageRecordSummaryList",
-    "body": "$stripe->subscriptionItems->allUsageRecordSummaries(\n  '${1:si_xxxxxxxxxxxxx}',\n  ['limit' => ${2:3}]\n)",
+    "body": "\\$stripe->subscriptionItems->allUsageRecordSummaries(\n  '${1:si_xxxxxxxxxxxxx}',\n  ['limit' => ${2:3}]\n)",
     "description": "List Subscription Item Usage Record Summary"
   },
   "Create Account": {
     "prefix": "StripeAccountCreate",
-    "body": "$stripe->accounts->create([\n  'type' => '${1:custom}',\n  'country' => '${2:US}',\n  'email' => '${3:jenny.rosen@example.com}',\n  'capabilities' => [\n    'card_payments' => ['requested' => ${4:${5:true}}],\n    'transfers' => ['requested' => true],\n  ],\n])",
+    "body": "\\$stripe->accounts->create([\n  'type' => '${1:custom}',\n  'country' => '${2:US}',\n  'email' => '${3:jenny.rosen@example.com}',\n  'capabilities' => [\n    'card_payments' => ['requested' => ${4:${5:true}}],\n    'transfers' => ['requested' => true],\n  ],\n])",
     "description": "Create Account"
   },
   "Retrieve Account": {
     "prefix": "StripeAccountRetrieve",
-    "body": "$stripe->accounts->retrieve(\n  '${1:acct_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->accounts->retrieve(\n  '${1:acct_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Retrieve Account"
   },
   "Update Account": {
     "prefix": "StripeAccountUpdate",
-    "body": "$stripe->accounts->update(\n  '${1:acct_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${2:6735}']]\n)",
+    "body": "\\$stripe->accounts->update(\n  '${1:acct_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${2:6735}']]\n)",
     "description": "Update Account"
   },
   "Delete Account": {
     "prefix": "StripeAccountDelete",
-    "body": "$stripe->accounts->delete(\n  '${1:acct_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->accounts->delete(\n  '${1:acct_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Delete Account"
   },
   "Reject Account": {
     "prefix": "StripeAccountReject",
-    "body": "$stripe->accounts->reject(\n  '${1:acct_xxxxxxxxxxxxx}',\n  ['reason' => '${2:fraud}']\n)",
+    "body": "\\$stripe->accounts->reject(\n  '${1:acct_xxxxxxxxxxxxx}',\n  ['reason' => '${2:fraud}']\n)",
     "description": "Reject Account"
   },
   "List Account": {
     "prefix": "StripeAccountList",
-    "body": "$stripe->accounts->all(['limit' => ${1:3}])",
+    "body": "\\$stripe->accounts->all(['limit' => ${1:3}])",
     "description": "List Account"
   },
   "Create Account Login Link": {
     "prefix": "StripeAccountLoginLinkCreate",
-    "body": "$stripe->accounts->createLoginLink(\n  '${1:acct_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->accounts->createLoginLink(\n  '${1:acct_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Create Account Login Link"
   },
   "Create Account Link": {
     "prefix": "StripeAccountLinkCreate",
-    "body": "$stripe->accountLinks->create([\n  'account' => '${1:acct_xxxxxxxxxxxxx}',\n  'refresh_url' => '${2:https://example.com/reauth}',\n  'return_url' => '${3:https://example.com/return}',\n  'type' => '${4:account_onboarding}',\n])",
+    "body": "\\$stripe->accountLinks->create([\n  'account' => '${1:acct_xxxxxxxxxxxxx}',\n  'refresh_url' => '${2:https://example.com/reauth}',\n  'return_url' => '${3:https://example.com/return}',\n  'type' => '${4:account_onboarding}',\n])",
     "description": "Create Account Link"
   },
   "Retrieve Application Fee": {
     "prefix": "StripeApplicationFeeRetrieve",
-    "body": "$stripe->applicationFees->retrieve(\n  '${1:fee_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->applicationFees->retrieve(\n  '${1:fee_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Retrieve Application Fee"
   },
   "List Application Fee": {
     "prefix": "StripeApplicationFeeList",
-    "body": "$stripe->applicationFees->all(['limit' => ${1:3}])",
+    "body": "\\$stripe->applicationFees->all(['limit' => ${1:3}])",
     "description": "List Application Fee"
   },
   "Create Application Fee Fee Refund": {
     "prefix": "StripeApplicationFeeFeeRefundCreate",
-    "body": "$stripe->applicationFees->createRefund(\n  '${1:fee_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->applicationFees->createRefund(\n  '${1:fee_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Create Application Fee Fee Refund"
   },
   "Retrieve Application Fee Fee Refund": {
     "prefix": "StripeApplicationFeeFeeRefundRetrieve",
-    "body": "$stripe->applicationFees->retrieveRefund(\n  '${2:fee_xxxxxxxxxxxxx}',\n  '${1:fr_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->applicationFees->retrieveRefund(\n  '${2:fee_xxxxxxxxxxxxx}',\n  '${1:fr_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Retrieve Application Fee Fee Refund"
   },
   "Update Application Fee Fee Refund": {
     "prefix": "StripeApplicationFeeFeeRefundUpdate",
-    "body": "$stripe->applicationFees->updateRefund(\n  '${2:fee_xxxxxxxxxxxxx}',\n  '${1:fr_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${3:6735}']]\n)",
+    "body": "\\$stripe->applicationFees->updateRefund(\n  '${2:fee_xxxxxxxxxxxxx}',\n  '${1:fr_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${3:6735}']]\n)",
     "description": "Update Application Fee Fee Refund"
   },
   "List Application Fee Fee Refund": {
     "prefix": "StripeApplicationFeeFeeRefundList",
-    "body": "$stripe->applicationFees->allRefunds(\n  '${1:fee_xxxxxxxxxxxxx}',\n  ['limit' => ${2:3}]\n)",
+    "body": "\\$stripe->applicationFees->allRefunds(\n  '${1:fee_xxxxxxxxxxxxx}',\n  ['limit' => ${2:3}]\n)",
     "description": "List Application Fee Fee Refund"
   },
   "Retrieve Account Capability": {
     "prefix": "StripeAccountCapabilityRetrieve",
-    "body": "$stripe->accounts->retrieveCapability(\n  '${2:acct_xxxxxxxxxxxxx}',\n  '${1:card_payments}',\n  []\n)",
+    "body": "\\$stripe->accounts->retrieveCapability(\n  '${2:acct_xxxxxxxxxxxxx}',\n  '${1:card_payments}',\n  []\n)",
     "description": "Retrieve Account Capability"
   },
   "Update Account Capability": {
     "prefix": "StripeAccountCapabilityUpdate",
-    "body": "$stripe->accounts->updateCapability(\n  '${2:acct_xxxxxxxxxxxxx}',\n  '${1:card_payments}',\n  ['requested' => ${3:true}]\n)",
+    "body": "\\$stripe->accounts->updateCapability(\n  '${2:acct_xxxxxxxxxxxxx}',\n  '${1:card_payments}',\n  ['requested' => ${3:true}]\n)",
     "description": "Update Account Capability"
   },
   "List Account Capability": {
     "prefix": "StripeAccountCapabilityList",
-    "body": "$stripe->accounts->allCapabilities(\n  '${1:acct_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->accounts->allCapabilities(\n  '${1:acct_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "List Account Capability"
   },
   "List Country Spec": {
     "prefix": "StripeCountrySpecList",
-    "body": "$stripe->countrySpecs->all(['limit' => ${1:3}])",
+    "body": "\\$stripe->countrySpecs->all(['limit' => ${1:3}])",
     "description": "List Country Spec"
   },
   "Retrieve Country Spec": {
     "prefix": "StripeCountrySpecRetrieve",
-    "body": "$stripe->countrySpecs->retrieve('${1:US}', [])",
+    "body": "\\$stripe->countrySpecs->retrieve('${1:US}', [])",
     "description": "Retrieve Country Spec"
   },
   "Create Account Account Bank Account": {
     "prefix": "StripeAccountAccountBankAccountCreate",
-    "body": "$stripe->accounts->createExternalAccount(\n  '${1:acct_xxxxxxxxxxxxx}',\n  ['external_account' => '${2:btok_xxxxxxxxxxxxx}']\n)",
+    "body": "\\$stripe->accounts->createExternalAccount(\n  '${1:acct_xxxxxxxxxxxxx}',\n  ['external_account' => '${2:btok_xxxxxxxxxxxxx}']\n)",
     "description": "Create Account Account Bank Account"
   },
   "Retrieve Account Account Bank Account": {
     "prefix": "StripeAccountAccountBankAccountRetrieve",
-    "body": "$stripe->accounts->retrieveExternalAccount(\n  '${2:acct_xxxxxxxxxxxxx}',\n  '${1:ba_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->accounts->retrieveExternalAccount(\n  '${2:acct_xxxxxxxxxxxxx}',\n  '${1:ba_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Retrieve Account Account Bank Account"
   },
   "Update Account Account Bank Account": {
     "prefix": "StripeAccountAccountBankAccountUpdate",
-    "body": "$stripe->accounts->updateExternalAccount(\n  '${2:acct_xxxxxxxxxxxxx}',\n  '${1:ba_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${3:6735}']]\n)",
+    "body": "\\$stripe->accounts->updateExternalAccount(\n  '${2:acct_xxxxxxxxxxxxx}',\n  '${1:ba_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${3:6735}']]\n)",
     "description": "Update Account Account Bank Account"
   },
   "Delete Account Account Bank Account": {
     "prefix": "StripeAccountAccountBankAccountDelete",
-    "body": "$stripe->accounts->deleteExternalAccount(\n  '${2:acct_xxxxxxxxxxxxx}',\n  '${1:ba_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->accounts->deleteExternalAccount(\n  '${2:acct_xxxxxxxxxxxxx}',\n  '${1:ba_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Delete Account Account Bank Account"
   },
   "List Account Account Bank Account": {
     "prefix": "StripeAccountAccountBankAccountList",
-    "body": "$stripe->accounts->allExternalAccounts(\n  '${1:acct_xxxxxxxxxxxxx}',\n  ['object' => '${2:bank_account}', 'limit' => ${3:3}]\n)",
+    "body": "\\$stripe->accounts->allExternalAccounts(\n  '${1:acct_xxxxxxxxxxxxx}',\n  ['object' => '${2:bank_account}', 'limit' => ${3:3}]\n)",
     "description": "List Account Account Bank Account"
   },
   "Create Account Account Card": {
     "prefix": "StripeAccountAccountCardCreate",
-    "body": "$stripe->accounts->createExternalAccount(\n  '${1:acct_xxxxxxxxxxxxx}',\n  ['external_account' => '${2:tok_xxxx_debit}']\n)",
+    "body": "\\$stripe->accounts->createExternalAccount(\n  '${1:acct_xxxxxxxxxxxxx}',\n  ['external_account' => '${2:tok_xxxx_debit}']\n)",
     "description": "Create Account Account Card"
   },
   "Retrieve Account Account Card": {
     "prefix": "StripeAccountAccountCardRetrieve",
-    "body": "$stripe->accounts->retrieveExternalAccount(\n  '${2:acct_xxxxxxxxxxxxx}',\n  '${1:card_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->accounts->retrieveExternalAccount(\n  '${2:acct_xxxxxxxxxxxxx}',\n  '${1:card_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Retrieve Account Account Card"
   },
   "Update Account Account Card": {
     "prefix": "StripeAccountAccountCardUpdate",
-    "body": "$stripe->accounts->updateExternalAccount(\n  '${2:acct_xxxxxxxxxxxxx}',\n  '${1:card_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${3:6735}']]\n)",
+    "body": "\\$stripe->accounts->updateExternalAccount(\n  '${2:acct_xxxxxxxxxxxxx}',\n  '${1:card_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${3:6735}']]\n)",
     "description": "Update Account Account Card"
   },
   "Delete Account Account Card": {
     "prefix": "StripeAccountAccountCardDelete",
-    "body": "$stripe->accounts->deleteExternalAccount(\n  '${2:acct_xxxxxxxxxxxxx}',\n  '${1:card_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->accounts->deleteExternalAccount(\n  '${2:acct_xxxxxxxxxxxxx}',\n  '${1:card_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Delete Account Account Card"
   },
   "List Account Account Card": {
     "prefix": "StripeAccountAccountCardList",
-    "body": "$stripe->accounts->allExternalAccounts(\n  '${1:acct_xxxxxxxxxxxxx}',\n  ['object' => '${2:card}', 'limit' => ${3:3}]\n)",
+    "body": "\\$stripe->accounts->allExternalAccounts(\n  '${1:acct_xxxxxxxxxxxxx}',\n  ['object' => '${2:card}', 'limit' => ${3:3}]\n)",
     "description": "List Account Account Card"
   },
   "Create Account Person": {
     "prefix": "StripeAccountPersonCreate",
-    "body": "$stripe->accounts->createPerson(\n  '${1:acct_xxxxxxxxxxxxx}',\n  ['first_name' => '${2:Jane}', 'last_name' => '${3:Diaz}']\n)",
+    "body": "\\$stripe->accounts->createPerson(\n  '${1:acct_xxxxxxxxxxxxx}',\n  ['first_name' => '${2:Jane}', 'last_name' => '${3:Diaz}']\n)",
     "description": "Create Account Person"
   },
   "Retrieve Account Person": {
     "prefix": "StripeAccountPersonRetrieve",
-    "body": "$stripe->accounts->retrievePerson(\n  '${2:acct_xxxxxxxxxxxxx}',\n  '${1:person_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->accounts->retrievePerson(\n  '${2:acct_xxxxxxxxxxxxx}',\n  '${1:person_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Retrieve Account Person"
   },
   "Update Account Person": {
     "prefix": "StripeAccountPersonUpdate",
-    "body": "$stripe->accounts->updatePerson(\n  '${2:acct_xxxxxxxxxxxxx}',\n  '${1:person_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${3:6735}']]\n)",
+    "body": "\\$stripe->accounts->updatePerson(\n  '${2:acct_xxxxxxxxxxxxx}',\n  '${1:person_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${3:6735}']]\n)",
     "description": "Update Account Person"
   },
   "Delete Account Person": {
     "prefix": "StripeAccountPersonDelete",
-    "body": "$stripe->accounts->deletePerson(\n  '${2:acct_xxxxxxxxxxxxx}',\n  '${1:person_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->accounts->deletePerson(\n  '${2:acct_xxxxxxxxxxxxx}',\n  '${1:person_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Delete Account Person"
   },
   "List Account Person": {
     "prefix": "StripeAccountPersonList",
-    "body": "$stripe->accounts->allPersons(\n  '${1:acct_xxxxxxxxxxxxx}',\n  ['limit' => ${2:3}]\n)",
+    "body": "\\$stripe->accounts->allPersons(\n  '${1:acct_xxxxxxxxxxxxx}',\n  ['limit' => ${2:3}]\n)",
     "description": "List Account Person"
   },
   "Create Topup": {
     "prefix": "StripeTopupCreate",
-    "body": "$stripe->topups->create([\n  'amount' => ${1:2000},\n  'currency' => '${2:usd}',\n  'description' => '${3:Top-up for Jenny Rosen}',\n  'statement_descriptor' => '${4:Top-up}',\n])",
+    "body": "\\$stripe->topups->create([\n  'amount' => ${1:2000},\n  'currency' => '${2:usd}',\n  'description' => '${3:Top-up for Jenny Rosen}',\n  'statement_descriptor' => '${4:Top-up}',\n])",
     "description": "Create Topup"
   },
   "Retrieve Topup": {
     "prefix": "StripeTopupRetrieve",
-    "body": "$stripe->topups->retrieve('${1:tu_xxxxxxxxxxxxx}', [])",
+    "body": "\\$stripe->topups->retrieve('${1:tu_xxxxxxxxxxxxx}', [])",
     "description": "Retrieve Topup"
   },
   "Update Topup": {
     "prefix": "StripeTopupUpdate",
-    "body": "$stripe->topups->update(\n  '${1:tu_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${2:6735}']]\n)",
+    "body": "\\$stripe->topups->update(\n  '${1:tu_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${2:6735}']]\n)",
     "description": "Update Topup"
   },
   "List Topup": {
     "prefix": "StripeTopupList",
-    "body": "$stripe->topups->all(['limit' => ${1:3}])",
+    "body": "\\$stripe->topups->all(['limit' => ${1:3}])",
     "description": "List Topup"
   },
   "Cancel Topup": {
     "prefix": "StripeTopupCancel",
-    "body": "$stripe->topups->cancel('${1:tu_xxxxxxxxxxxxx}', [])",
+    "body": "\\$stripe->topups->cancel('${1:tu_xxxxxxxxxxxxx}', [])",
     "description": "Cancel Topup"
   },
   "Create Transfer": {
     "prefix": "StripeTransferCreate",
-    "body": "$stripe->transfers->create([\n  'amount' => ${1:400},\n  'currency' => '${2:usd}',\n  'destination' => '${3:acct_xxxxxxxxxxxxx}',\n  'transfer_group' => '${4:ORDER_95}',\n])",
+    "body": "\\$stripe->transfers->create([\n  'amount' => ${1:400},\n  'currency' => '${2:usd}',\n  'destination' => '${3:acct_xxxxxxxxxxxxx}',\n  'transfer_group' => '${4:ORDER_95}',\n])",
     "description": "Create Transfer"
   },
   "Retrieve Transfer": {
     "prefix": "StripeTransferRetrieve",
-    "body": "$stripe->transfers->retrieve(\n  '${1:tr_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->transfers->retrieve(\n  '${1:tr_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Retrieve Transfer"
   },
   "Update Transfer": {
     "prefix": "StripeTransferUpdate",
-    "body": "$stripe->transfers->update(\n  '${1:tr_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${2:6735}']]\n)",
+    "body": "\\$stripe->transfers->update(\n  '${1:tr_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${2:6735}']]\n)",
     "description": "Update Transfer"
   },
   "List Transfer": {
     "prefix": "StripeTransferList",
-    "body": "$stripe->transfers->all(['limit' => ${1:3}])",
+    "body": "\\$stripe->transfers->all(['limit' => ${1:3}])",
     "description": "List Transfer"
   },
   "Create Transfer Reversal": {
     "prefix": "StripeTransferReversalCreate",
-    "body": "$stripe->transfers->createReversal(\n  '${1:tr_xxxxxxxxxxxxx}',\n  ['amount' => ${2:100}]\n)",
+    "body": "\\$stripe->transfers->createReversal(\n  '${1:tr_xxxxxxxxxxxxx}',\n  ['amount' => ${2:100}]\n)",
     "description": "Create Transfer Reversal"
   },
   "Retrieve Transfer Reversal": {
     "prefix": "StripeTransferReversalRetrieve",
-    "body": "$stripe->transfers->retrieveReversal(\n  '${2:tr_xxxxxxxxxxxxx}',\n  '${1:trr_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->transfers->retrieveReversal(\n  '${2:tr_xxxxxxxxxxxxx}',\n  '${1:trr_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Retrieve Transfer Reversal"
   },
   "Update Transfer Reversal": {
     "prefix": "StripeTransferReversalUpdate",
-    "body": "$stripe->transfers->updateReversal(\n  '${2:tr_xxxxxxxxxxxxx}',\n  '${1:trr_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${3:6735}']]\n)",
+    "body": "\\$stripe->transfers->updateReversal(\n  '${2:tr_xxxxxxxxxxxxx}',\n  '${1:trr_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${3:6735}']]\n)",
     "description": "Update Transfer Reversal"
   },
   "List Transfer Reversal": {
     "prefix": "StripeTransferReversalList",
-    "body": "$stripe->transfers->allReversals(\n  '${1:tr_xxxxxxxxxxxxx}',\n  ['limit' => ${2:3}]\n)",
+    "body": "\\$stripe->transfers->allReversals(\n  '${1:tr_xxxxxxxxxxxxx}',\n  ['limit' => ${2:3}]\n)",
     "description": "List Transfer Reversal"
   },
   "Retrieve Radar Early Fraud Warning": {
     "prefix": "StripeRadarEarlyFraudWarningRetrieve",
-    "body": "$stripe->radar->earlyFraudWarnings->retrieve(\n  '${1:issfr_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->radar->earlyFraudWarnings->retrieve(\n  '${1:issfr_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Retrieve Radar Early Fraud Warning"
   },
   "List Radar Early Fraud Warning": {
     "prefix": "StripeRadarEarlyFraudWarningList",
-    "body": "$stripe->radar->earlyFraudWarnings->all([\n  'limit' => ${1:3},\n])",
+    "body": "\\$stripe->radar->earlyFraudWarnings->all([\n  'limit' => ${1:3},\n])",
     "description": "List Radar Early Fraud Warning"
   },
   "Approve Review": {
     "prefix": "StripeReviewApprove",
-    "body": "$stripe->reviews->approve('${1:prv_xxxxxxxxxxxxx}', [])",
+    "body": "\\$stripe->reviews->approve('${1:prv_xxxxxxxxxxxxx}', [])",
     "description": "Approve Review"
   },
   "Retrieve Review": {
     "prefix": "StripeReviewRetrieve",
-    "body": "$stripe->reviews->retrieve(\n  '${1:prv_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->reviews->retrieve(\n  '${1:prv_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Retrieve Review"
   },
   "List Review": {
     "prefix": "StripeReviewList",
-    "body": "$stripe->reviews->all(['limit' => ${1:3}])",
+    "body": "\\$stripe->reviews->all(['limit' => ${1:3}])",
     "description": "List Review"
   },
   "Create Radar Value List": {
     "prefix": "StripeRadarValueListCreate",
-    "body": "$stripe->radar->valueLists->create([\n  'alias' => '${1:custom_ip_xxxxxxxxxxxxx}',\n  'name' => '${2:Custom IP Blocklist}',\n  'item_type' => '${3:ip_address}',\n])",
+    "body": "\\$stripe->radar->valueLists->create([\n  'alias' => '${1:custom_ip_xxxxxxxxxxxxx}',\n  'name' => '${2:Custom IP Blocklist}',\n  'item_type' => '${3:ip_address}',\n])",
     "description": "Create Radar Value List"
   },
   "Retrieve Radar Value List": {
     "prefix": "StripeRadarValueListRetrieve",
-    "body": "$stripe->radar->valueLists->retrieve(\n  '${1:rsl_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->radar->valueLists->retrieve(\n  '${1:rsl_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Retrieve Radar Value List"
   },
   "Update Radar Value List": {
     "prefix": "StripeRadarValueListUpdate",
-    "body": "$stripe->radar->valueLists->update(\n  '${1:rsl_xxxxxxxxxxxxx}',\n  ['name' => '${2:Updated IP Block List}']\n)",
+    "body": "\\$stripe->radar->valueLists->update(\n  '${1:rsl_xxxxxxxxxxxxx}',\n  ['name' => '${2:Updated IP Block List}']\n)",
     "description": "Update Radar Value List"
   },
   "Delete Radar Value List": {
     "prefix": "StripeRadarValueListDelete",
-    "body": "$stripe->radar->valueLists->delete(\n  '${1:rsl_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->radar->valueLists->delete(\n  '${1:rsl_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Delete Radar Value List"
   },
   "List Radar Value List": {
     "prefix": "StripeRadarValueListList",
-    "body": "$stripe->radar->valueLists->all(['limit' => ${1:3}])",
+    "body": "\\$stripe->radar->valueLists->all(['limit' => ${1:3}])",
     "description": "List Radar Value List"
   },
   "Create Radar Value List Item": {
     "prefix": "StripeRadarValueListItemCreate",
-    "body": "$stripe->radar->valueListItems->create([\n  'value_list' => '${1:rsl_xxxxxxxxxxxxx}',\n  'value' => '${2:1.2.3.4}',\n])",
+    "body": "\\$stripe->radar->valueListItems->create([\n  'value_list' => '${1:rsl_xxxxxxxxxxxxx}',\n  'value' => '${2:1.2.3.4}',\n])",
     "description": "Create Radar Value List Item"
   },
   "Retrieve Radar Value List Item": {
     "prefix": "StripeRadarValueListItemRetrieve",
-    "body": "$stripe->radar->valueListItems->retrieve(\n  '${1:rsli_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->radar->valueListItems->retrieve(\n  '${1:rsli_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Retrieve Radar Value List Item"
   },
   "Delete Radar Value List Item": {
     "prefix": "StripeRadarValueListItemDelete",
-    "body": "$stripe->radar->valueListItems->delete(\n  '${1:rsli_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->radar->valueListItems->delete(\n  '${1:rsli_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Delete Radar Value List Item"
   },
   "List Radar Value List Item": {
     "prefix": "StripeRadarValueListItemList",
-    "body": "$stripe->radar->valueListItems->all([\n  'limit' => ${1:3},\n  'value_list' => '${2:rsl_xxxxxxxxxxxxx}',\n])",
+    "body": "\\$stripe->radar->valueListItems->all([\n  'limit' => ${1:3},\n  'value_list' => '${2:rsl_xxxxxxxxxxxxx}',\n])",
     "description": "List Radar Value List Item"
   },
   "Retrieve Issuing Authorization": {
     "prefix": "StripeIssuingAuthorizationRetrieve",
-    "body": "$stripe->issuing->authorizations->retrieve(\n  '${1:iauth_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->issuing->authorizations->retrieve(\n  '${1:iauth_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Retrieve Issuing Authorization"
   },
   "Update Issuing Authorization": {
     "prefix": "StripeIssuingAuthorizationUpdate",
-    "body": "$stripe->issuing->authorizations->update(\n  '${1:iauth_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${2:6735}']]\n)",
+    "body": "\\$stripe->issuing->authorizations->update(\n  '${1:iauth_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${2:6735}']]\n)",
     "description": "Update Issuing Authorization"
   },
   "Approve Issuing Authorization": {
     "prefix": "StripeIssuingAuthorizationApprove",
-    "body": "$stripe->issuing->authorizations->approve(\n  '${1:iauth_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->issuing->authorizations->approve(\n  '${1:iauth_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Approve Issuing Authorization"
   },
   "Decline Issuing Authorization": {
     "prefix": "StripeIssuingAuthorizationDecline",
-    "body": "$stripe->issuing->authorizations->decline(\n  '${1:iauth_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->issuing->authorizations->decline(\n  '${1:iauth_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Decline Issuing Authorization"
   },
   "List Issuing Authorization": {
     "prefix": "StripeIssuingAuthorizationList",
-    "body": "$stripe->issuing->authorizations->all([\n  'limit' => ${1:3},\n])",
+    "body": "\\$stripe->issuing->authorizations->all([\n  'limit' => ${1:3},\n])",
     "description": "List Issuing Authorization"
   },
   "Create Issuing Cardholder": {
     "prefix": "StripeIssuingCardholderCreate",
-    "body": "$stripe->issuing->cardholders->create([\n  'type' => '${1:individual}',\n  'name' => '${2:Jenny Rosen}',\n  'email' => '${3:jenny.rosen@example.com}',\n  'phone_number' => '${4:+18888675309}',\n  'billing' => [\n    'address' => [\n      'line1' => '${5:1234 Main Street}',\n      'city' => '${6:San Francisco}',\n      'state' => '${7:CA}',\n      'country' => '${8:US}',\n      'postal_code' => '${9:94111}',\n    ],\n  ],\n])",
+    "body": "\\$stripe->issuing->cardholders->create([\n  'type' => '${1:individual}',\n  'name' => '${2:Jenny Rosen}',\n  'email' => '${3:jenny.rosen@example.com}',\n  'phone_number' => '${4:+18888675309}',\n  'billing' => [\n    'address' => [\n      'line1' => '${5:1234 Main Street}',\n      'city' => '${6:San Francisco}',\n      'state' => '${7:CA}',\n      'country' => '${8:US}',\n      'postal_code' => '${9:94111}',\n    ],\n  ],\n])",
     "description": "Create Issuing Cardholder"
   },
   "Retrieve Issuing Cardholder": {
     "prefix": "StripeIssuingCardholderRetrieve",
-    "body": "$stripe->issuing->cardholders->retrieve(\n  '${1:ich_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->issuing->cardholders->retrieve(\n  '${1:ich_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Retrieve Issuing Cardholder"
   },
   "Update Issuing Cardholder": {
     "prefix": "StripeIssuingCardholderUpdate",
-    "body": "$stripe->issuing->cardholders->update(\n  '${1:ich_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${2:6735}']]\n)",
+    "body": "\\$stripe->issuing->cardholders->update(\n  '${1:ich_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${2:6735}']]\n)",
     "description": "Update Issuing Cardholder"
   },
   "List Issuing Cardholder": {
     "prefix": "StripeIssuingCardholderList",
-    "body": "$stripe->issuing->cardholders->all(['limit' => ${1:3}])",
+    "body": "\\$stripe->issuing->cardholders->all(['limit' => ${1:3}])",
     "description": "List Issuing Cardholder"
   },
   "Create Issuing Card": {
     "prefix": "StripeIssuingCardCreate",
-    "body": "$stripe->issuing->cards->create([\n  'cardholder' => '${1:ich_xxxxxxxxxxxxx}',\n  'currency' => '${2:usd}',\n  'type' => '${3:virtual}',\n])",
+    "body": "\\$stripe->issuing->cards->create([\n  'cardholder' => '${1:ich_xxxxxxxxxxxxx}',\n  'currency' => '${2:usd}',\n  'type' => '${3:virtual}',\n])",
     "description": "Create Issuing Card"
   },
   "Retrieve Issuing Card": {
     "prefix": "StripeIssuingCardRetrieve",
-    "body": "$stripe->issuing->cards->retrieve(\n  '${1:ic_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->issuing->cards->retrieve(\n  '${1:ic_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Retrieve Issuing Card"
   },
   "Update Issuing Card": {
     "prefix": "StripeIssuingCardUpdate",
-    "body": "$stripe->issuing->cards->update(\n  '${1:ic_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${2:6735}']]\n)",
+    "body": "\\$stripe->issuing->cards->update(\n  '${1:ic_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${2:6735}']]\n)",
     "description": "Update Issuing Card"
   },
   "List Issuing Card": {
     "prefix": "StripeIssuingCardList",
-    "body": "$stripe->issuing->cards->all(['limit' => ${1:3}])",
+    "body": "\\$stripe->issuing->cards->all(['limit' => ${1:3}])",
     "description": "List Issuing Card"
   },
   "Create Issuing Dispute": {
     "prefix": "StripeIssuingDisputeCreate",
-    "body": "$stripe->issuing->disputes->create([\n  'transaction' => '${1:ipi_xxxxxxxxxxxxx}',\n  'evidence' => [\n    'reason' => '${2:fraudulent}',\n    'fraudulent' => [\n      'explanation' => '${3:Purchase was unrecognized.}',\n    ],\n  ],\n])",
+    "body": "\\$stripe->issuing->disputes->create([\n  'transaction' => '${1:ipi_xxxxxxxxxxxxx}',\n  'evidence' => [\n    'reason' => '${2:fraudulent}',\n    'fraudulent' => [\n      'explanation' => '${3:Purchase was unrecognized.}',\n    ],\n  ],\n])",
     "description": "Create Issuing Dispute"
   },
   "Submit Issuing Dispute": {
     "prefix": "StripeIssuingDisputeSubmit",
-    "body": "$stripe->issuing->disputes->submit(\n  '${1:idp_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->issuing->disputes->submit(\n  '${1:idp_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Submit Issuing Dispute"
   },
   "Retrieve Issuing Dispute": {
     "prefix": "StripeIssuingDisputeRetrieve",
-    "body": "$stripe->issuing->disputes->retrieve(\n  '${1:idp_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->issuing->disputes->retrieve(\n  '${1:idp_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Retrieve Issuing Dispute"
   },
   "Update Issuing Dispute": {
     "prefix": "StripeIssuingDisputeUpdate",
-    "body": "$stripe->issuing->disputes->update(\n  '${1:idp_xxxxxxxxxxxxx}',\n  [\n    'evidence' => [\n      'reason' => '${2:not_xxxxxxxxxxxxx}',\n      'not_received' => [\n        'expected_at' => ${3:1590000000},\n        'explanation${4:}' => '',\n        'product_description' => '${5:Baseball cap}',\n        'product_type' => '${6:merchandise}',\n      ],\n    ],\n  ]\n)",
+    "body": "\\$stripe->issuing->disputes->update(\n  '${1:idp_xxxxxxxxxxxxx}',\n  [\n    'evidence' => [\n      'reason' => '${2:not_xxxxxxxxxxxxx}',\n      'not_received' => [\n        'expected_at' => ${3:1590000000},\n        'explanation${4:}' => '',\n        'product_description' => '${5:Baseball cap}',\n        'product_type' => '${6:merchandise}',\n      ],\n    ],\n  ]\n)",
     "description": "Update Issuing Dispute"
   },
   "List Issuing Dispute": {
     "prefix": "StripeIssuingDisputeList",
-    "body": "$stripe->issuing->disputes->all(['limit' => ${1:3}])",
+    "body": "\\$stripe->issuing->disputes->all(['limit' => ${1:3}])",
     "description": "List Issuing Dispute"
   },
   "Retrieve Issuing Transaction": {
     "prefix": "StripeIssuingTransactionRetrieve",
-    "body": "$stripe->issuing->transactions->retrieve(\n  '${1:ipi_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->issuing->transactions->retrieve(\n  '${1:ipi_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Retrieve Issuing Transaction"
   },
   "Update Issuing Transaction": {
     "prefix": "StripeIssuingTransactionUpdate",
-    "body": "$stripe->issuing->transactions->update(\n  '${1:ipi_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${2:6735}']]\n)",
+    "body": "\\$stripe->issuing->transactions->update(\n  '${1:ipi_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${2:6735}']]\n)",
     "description": "Update Issuing Transaction"
   },
   "List Issuing Transaction": {
     "prefix": "StripeIssuingTransactionList",
-    "body": "$stripe->issuing->transactions->all([\n  'limit' => ${1:3},\n])",
+    "body": "\\$stripe->issuing->transactions->all([\n  'limit' => ${1:3},\n])",
     "description": "List Issuing Transaction"
   },
   "Create Terminal Connection Token": {
     "prefix": "StripeTerminalConnectionTokenCreate",
-    "body": "$stripe->terminal->connectionTokens->create([])",
+    "body": "\\$stripe->terminal->connectionTokens->create([])",
     "description": "Create Terminal Connection Token"
   },
   "Create Terminal Location": {
     "prefix": "StripeTerminalLocationCreate",
-    "body": "$stripe->terminal->locations->create([\n  'display_name' => '${1:My First Store}',\n  'address' => [\n    'line1' => '${2:1234 Main Street}',\n    'city' => '${3:San Francisco}',\n    'country' => '${4:US}',\n    'postal_code' => '${5:94111}',\n  ],\n])",
+    "body": "\\$stripe->terminal->locations->create([\n  'display_name' => '${1:My First Store}',\n  'address' => [\n    'line1' => '${2:1234 Main Street}',\n    'city' => '${3:San Francisco}',\n    'country' => '${4:US}',\n    'postal_code' => '${5:94111}',\n  ],\n])",
     "description": "Create Terminal Location"
   },
   "Retrieve Terminal Location": {
     "prefix": "StripeTerminalLocationRetrieve",
-    "body": "$stripe->terminal->locations->retrieve(\n  '${1:tml_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->terminal->locations->retrieve(\n  '${1:tml_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Retrieve Terminal Location"
   },
   "Update Terminal Location": {
     "prefix": "StripeTerminalLocationUpdate",
-    "body": "$stripe->terminal->locations->update(\n  '${1:tml_xxxxxxxxxxxxx}',\n  ['display_name' => '${2:My First Store}']\n)",
+    "body": "\\$stripe->terminal->locations->update(\n  '${1:tml_xxxxxxxxxxxxx}',\n  ['display_name' => '${2:My First Store}']\n)",
     "description": "Update Terminal Location"
   },
   "Delete Terminal Location": {
     "prefix": "StripeTerminalLocationDelete",
-    "body": "$stripe->terminal->locations->delete(\n  '${1:tml_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->terminal->locations->delete(\n  '${1:tml_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Delete Terminal Location"
   },
   "List Terminal Location": {
     "prefix": "StripeTerminalLocationList",
-    "body": "$stripe->terminal->locations->all(['limit' => ${1:3}])",
+    "body": "\\$stripe->terminal->locations->all(['limit' => ${1:3}])",
     "description": "List Terminal Location"
   },
   "Create Terminal Reader": {
     "prefix": "StripeTerminalReaderCreate",
-    "body": "$stripe->terminal->readers->create([\n  'registration_code' => '${1:puppies-plug-could}',\n  'label' => '${2:Blue Rabbit}',\n  'location' => '${3:tml_1234}',\n])",
+    "body": "\\$stripe->terminal->readers->create([\n  'registration_code' => '${1:puppies-plug-could}',\n  'label' => '${2:Blue Rabbit}',\n  'location' => '${3:tml_1234}',\n])",
     "description": "Create Terminal Reader"
   },
   "Retrieve Terminal Reader": {
     "prefix": "StripeTerminalReaderRetrieve",
-    "body": "$stripe->terminal->readers->retrieve(\n  '${1:tmr_P400-123-456-789}',\n  []\n)",
+    "body": "\\$stripe->terminal->readers->retrieve(\n  '${1:tmr_P400-123-456-789}',\n  []\n)",
     "description": "Retrieve Terminal Reader"
   },
   "Update Terminal Reader": {
     "prefix": "StripeTerminalReaderUpdate",
-    "body": "$stripe->terminal->readers->update(\n  '${1:tmr_P400-123-456-789}',\n  ['label' => '${2:Blue Rabbit}']\n)",
+    "body": "\\$stripe->terminal->readers->update(\n  '${1:tmr_P400-123-456-789}',\n  ['label' => '${2:Blue Rabbit}']\n)",
     "description": "Update Terminal Reader"
   },
   "Delete Terminal Reader": {
     "prefix": "StripeTerminalReaderDelete",
-    "body": "$stripe->terminal->readers->delete(\n  '${1:tmr_P400-123-456-789}',\n  []\n)",
+    "body": "\\$stripe->terminal->readers->delete(\n  '${1:tmr_P400-123-456-789}',\n  []\n)",
     "description": "Delete Terminal Reader"
   },
   "List Terminal Reader": {
     "prefix": "StripeTerminalReaderList",
-    "body": "$stripe->terminal->readers->all(['limit' => ${1:3}])",
+    "body": "\\$stripe->terminal->readers->all(['limit' => ${1:3}])",
     "description": "List Terminal Reader"
   },
   "Create Order": {
     "prefix": "StripeOrderCreate",
-    "body": "$stripe->orders->create([\n  'currency' => '${1:usd}',\n  'email' => '${2:jenny.rosen@example.com}',\n  'items' => [\n    [\n      'type' => '${3:sku}',\n      'parent' => '${4:sku_xxxxxxxxxxxxx}',\n    ],\n  ],\n  'shipping' => [\n    'name' => '${5:Jenny Rosen}',\n    'address' => [\n      'line1' => '${6:1234 Main Street}',\n      'city' => '${7:San Francisco}',\n      'state' => '${8:CA}',\n      'country' => '${9:US}',\n      'postal_code' => '${10:94111}',\n    ],\n  ],\n])",
+    "body": "\\$stripe->orders->create([\n  'currency' => '${1:usd}',\n  'email' => '${2:jenny.rosen@example.com}',\n  'items' => [\n    [\n      'type' => '${3:sku}',\n      'parent' => '${4:sku_xxxxxxxxxxxxx}',\n    ],\n  ],\n  'shipping' => [\n    'name' => '${5:Jenny Rosen}',\n    'address' => [\n      'line1' => '${6:1234 Main Street}',\n      'city' => '${7:San Francisco}',\n      'state' => '${8:CA}',\n      'country' => '${9:US}',\n      'postal_code' => '${10:94111}',\n    ],\n  ],\n])",
     "description": "Create Order"
   },
   "Retrieve Order": {
     "prefix": "StripeOrderRetrieve",
-    "body": "$stripe->orders->retrieve('${1:or_xxxxxxxxxxxxx}', [])",
+    "body": "\\$stripe->orders->retrieve('${1:or_xxxxxxxxxxxxx}', [])",
     "description": "Retrieve Order"
   },
   "Update Order": {
     "prefix": "StripeOrderUpdate",
-    "body": "$stripe->orders->update(\n  '${1:or_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${2:6735}']]\n)",
+    "body": "\\$stripe->orders->update(\n  '${1:or_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${2:6735}']]\n)",
     "description": "Update Order"
   },
   "Pay Order": {
     "prefix": "StripeOrderPay",
-    "body": "$stripe->orders->pay(\n  '${1:or_xxxxxxxxxxxxx}',\n  ['source' => '${2:tok_xxxx}']\n)",
+    "body": "\\$stripe->orders->pay(\n  '${1:or_xxxxxxxxxxxxx}',\n  ['source' => '${2:tok_xxxx}']\n)",
     "description": "Pay Order"
   },
   "List Order": {
     "prefix": "StripeOrderList",
-    "body": "$stripe->orders->all(['limit' => ${1:3}])",
+    "body": "\\$stripe->orders->all(['limit' => ${1:3}])",
     "description": "List Order"
   },
   "Retrieve Order Return": {
     "prefix": "StripeOrderReturnRetrieve",
-    "body": "$stripe->orderReturns->retrieve(\n  '${1:orret_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->orderReturns->retrieve(\n  '${1:orret_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Retrieve Order Return"
   },
   "List Order Return": {
     "prefix": "StripeOrderReturnList",
-    "body": "$stripe->orderReturns->all(['limit' => ${1:3}])",
+    "body": "\\$stripe->orderReturns->all(['limit' => ${1:3}])",
     "description": "List Order Return"
   },
   "Create Sku": {
     "prefix": "StripeSkuCreate",
-    "body": "$stripe->skus->create([\n  'attributes' => [\n    'size' => '${1:Medium}',\n    'gender' => '${2:Unisex}',\n  ],\n  'price' => ${3:1500},\n  'currency' => '${4:usd}',\n  'inventory' => [\n    'type' => '${5:finite}',\n    'quantity' => ${6:500},\n  ],\n  'product' => '${7:prod_xxxxxxxxxxxxx}',\n])",
+    "body": "\\$stripe->skus->create([\n  'attributes' => [\n    'size' => '${1:Medium}',\n    'gender' => '${2:Unisex}',\n  ],\n  'price' => ${3:1500},\n  'currency' => '${4:usd}',\n  'inventory' => [\n    'type' => '${5:finite}',\n    'quantity' => ${6:500},\n  ],\n  'product' => '${7:prod_xxxxxxxxxxxxx}',\n])",
     "description": "Create Sku"
   },
   "Retrieve Sku": {
     "prefix": "StripeSkuRetrieve",
-    "body": "$stripe->skus->retrieve('${1:sku_xxxxxxxxxxxxx}', [])",
+    "body": "\\$stripe->skus->retrieve('${1:sku_xxxxxxxxxxxxx}', [])",
     "description": "Retrieve Sku"
   },
   "Update Sku": {
     "prefix": "StripeSkuUpdate",
-    "body": "$stripe->skus->update(\n  '${1:sku_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${2:6735}']]\n)",
+    "body": "\\$stripe->skus->update(\n  '${1:sku_xxxxxxxxxxxxx}',\n  ['metadata' => ['order_id' => '${2:6735}']]\n)",
     "description": "Update Sku"
   },
   "List Sku": {
     "prefix": "StripeSkuList",
-    "body": "$stripe->skus->all(['limit' => ${1:3}])",
+    "body": "\\$stripe->skus->all(['limit' => ${1:3}])",
     "description": "List Sku"
   },
   "Delete Sku": {
     "prefix": "StripeSkuDelete",
-    "body": "$stripe->skus->delete('${1:sku_xxxxxxxxxxxxx}', [])",
+    "body": "\\$stripe->skus->delete('${1:sku_xxxxxxxxxxxxx}', [])",
     "description": "Delete Sku"
   },
   "Retrieve Sigma Scheduled Query Run": {
     "prefix": "StripeSigmaScheduledQueryRunRetrieve",
-    "body": "$stripe->sigma->scheduledQueryRuns->retrieve(\n  '${1:sqr_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->sigma->scheduledQueryRuns->retrieve(\n  '${1:sqr_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Retrieve Sigma Scheduled Query Run"
   },
   "List Sigma Scheduled Query Run": {
     "prefix": "StripeSigmaScheduledQueryRunList",
-    "body": "$stripe->sigma->scheduledQueryRuns->all([\n  'limit' => ${1:3},\n])",
+    "body": "\\$stripe->sigma->scheduledQueryRuns->all([\n  'limit' => ${1:3},\n])",
     "description": "List Sigma Scheduled Query Run"
   },
   "Create Reporting Report Run": {
     "prefix": "StripeReportingReportRunCreate",
-    "body": "$stripe->reporting->reportRuns->create([\n  'report_type' => '${1:balance.summary.1}',\n  'parameters' => [\n    'interval_start' => ${2:1522540800},\n    'interval_end' => ${3:1525132800},\n  ],\n])",
+    "body": "\\$stripe->reporting->reportRuns->create([\n  'report_type' => '${1:balance.summary.1}',\n  'parameters' => [\n    'interval_start' => ${2:1522540800},\n    'interval_end' => ${3:1525132800},\n  ],\n])",
     "description": "Create Reporting Report Run"
   },
   "Retrieve Reporting Report Run": {
     "prefix": "StripeReportingReportRunRetrieve",
-    "body": "$stripe->reporting->reportRuns->retrieve(\n  '${1:frr_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->reporting->reportRuns->retrieve(\n  '${1:frr_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Retrieve Reporting Report Run"
   },
   "List Reporting Report Run": {
     "prefix": "StripeReportingReportRunList",
-    "body": "$stripe->reporting->reportRuns->all([\n  'limit' => ${1:3},\n])",
+    "body": "\\$stripe->reporting->reportRuns->all([\n  'limit' => ${1:3},\n])",
     "description": "List Reporting Report Run"
   },
   "Retrieve Reporting Report Type": {
     "prefix": "StripeReportingReportTypeRetrieve",
-    "body": "$stripe->reporting->reportTypes->retrieve(\n  '${1:balance.summary.1}',\n  []\n)",
+    "body": "\\$stripe->reporting->reportTypes->retrieve(\n  '${1:balance.summary.1}',\n  []\n)",
     "description": "Retrieve Reporting Report Type"
   },
   "List Reporting Report Type": {
     "prefix": "StripeReportingReportTypeList",
-    "body": "$stripe->reporting->reportTypes->all([])",
+    "body": "\\$stripe->reporting->reportTypes->all([])",
     "description": "List Reporting Report Type"
   },
   "Create Webhook Endpoint": {
     "prefix": "StripeWebhookEndpointCreate",
-    "body": "$stripe->webhookEndpoints->create([\n  'url' => '${1:https://example.com/my/webhook/endpoint}',\n  'enabled_events' => [\n    'charge.failed',\n    'charge.succeeded',\n  ],\n])",
+    "body": "\\$stripe->webhookEndpoints->create([\n  'url' => '${1:https://example.com/my/webhook/endpoint}',\n  'enabled_events' => [\n    'charge.failed',\n    'charge.succeeded',\n  ],\n])",
     "description": "Create Webhook Endpoint"
   },
   "Retrieve Webhook Endpoint": {
     "prefix": "StripeWebhookEndpointRetrieve",
-    "body": "$stripe->webhookEndpoints->retrieve(\n  '${1:we_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->webhookEndpoints->retrieve(\n  '${1:we_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Retrieve Webhook Endpoint"
   },
   "Update Webhook Endpoint": {
     "prefix": "StripeWebhookEndpointUpdate",
-    "body": "$stripe->webhookEndpoints->update(\n  '${1:we_xxxxxxxxxxxxx}',\n  ['url' => '${2:https://example.com/new_endpoint}']\n)",
+    "body": "\\$stripe->webhookEndpoints->update(\n  '${1:we_xxxxxxxxxxxxx}',\n  ['url' => '${2:https://example.com/new_endpoint}']\n)",
     "description": "Update Webhook Endpoint"
   },
   "List Webhook Endpoint": {
     "prefix": "StripeWebhookEndpointList",
-    "body": "$stripe->webhookEndpoints->all(['limit' => ${1:3}])",
+    "body": "\\$stripe->webhookEndpoints->all(['limit' => ${1:3}])",
     "description": "List Webhook Endpoint"
   },
   "Delete Webhook Endpoint": {
     "prefix": "StripeWebhookEndpointDelete",
-    "body": "$stripe->webhookEndpoints->delete(\n  '${1:we_xxxxxxxxxxxxx}',\n  []\n)",
+    "body": "\\$stripe->webhookEndpoints->delete(\n  '${1:we_xxxxxxxxxxxxx}',\n  []\n)",
     "description": "Delete Webhook Endpoint"
   }
 }


### PR DESCRIPTION
It gets interpreted as snippet-variables by VSCode instead of literal code.

Before:
![Screen Shot 2021-03-11 at 12 38 38 PM](https://user-images.githubusercontent.com/75757829/110852222-f1352880-8266-11eb-8451-490c983b1b57.png)

After: 
![Screen Shot 2021-03-11 at 1 32 36 PM](https://user-images.githubusercontent.com/75757829/110857900-4163b900-826e-11eb-9141-931146e4862c.png)




And this error goes away:
![Screen Shot 2021-03-11 at 12 13 38 PM](https://user-images.githubusercontent.com/75757829/110851961-9bf91700-8266-11eb-81f6-6f7a5c3759b9.png)


