### PR TITLE
Abstracting out streaming components of LogsView

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -124,12 +124,12 @@ export class Commands {
 
   startLogsStreaming = (stripeLogsViewProvider: StripeLogsViewProvider) => {
     this.telemetry.sendEvent('startLogsStreaming');
-    stripeLogsViewProvider.startLogsStreaming();
+    stripeLogsViewProvider.starStreaming();
   };
 
   stopLogsStreaming = (stripeLogsViewProvider: StripeLogsViewProvider) => {
     this.telemetry.sendEvent('stopLogsStreaming');
-    stripeLogsViewProvider.stopLogsStreaming();
+    stripeLogsViewProvider.stopStreaming();
   };
 
   startLogin = () => {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -124,7 +124,7 @@ export class Commands {
 
   startLogsStreaming = (stripeLogsViewProvider: StripeLogsViewProvider) => {
     this.telemetry.sendEvent('startLogsStreaming');
-    stripeLogsViewProvider.starStreaming();
+    stripeLogsViewProvider.startStreaming();
   };
 
   stopLogsStreaming = (stripeLogsViewProvider: StripeLogsViewProvider) => {

--- a/src/stripeLogsView.ts
+++ b/src/stripeLogsView.ts
@@ -1,17 +1,10 @@
 import {CLICommand, StripeClient} from './stripeClient';
-import {ThemeIcon, window} from 'vscode';
-import {debounce, unixToLocaleStringTZ} from './utils';
-import {LineStream} from 'byline';
+import {ChildProcess} from 'child_process';
+import {StreamingViewDataProvider} from './stripeStreamingView';
 import {StripeTreeItem} from './stripeTreeItem';
-import {StripeTreeViewDataProvider} from './stripeTreeViewDataProvider';
-import stream from 'stream';
+import {unixToLocaleStringTZ} from './utils';
 
-enum ViewState {
-  Idle,
-  Loading,
-  Streaming,
-}
-
+// Log object should have an isObject and method for how to create a label.
 type LogObject = {
   status: number;
   method: string;
@@ -35,72 +28,19 @@ export const isLogObject = (object: any): object is LogObject => {
   );
 };
 
-export class StripeLogsViewProvider extends StripeTreeViewDataProvider {
-  private static readonly REFRESH_DEBOUNCE_MILLIS = 1000;
-
-  private stripeClient: StripeClient;
-  private logTreeItems: StripeTreeItem[];
-  private viewState: ViewState;
-  private logsStdoutStream: stream.Writable | null;
-  private logsStderrStream: stream.Writable | null;
-
+export class StripeLogsViewProvider extends StreamingViewDataProvider {
   constructor(stripeClient: StripeClient) {
-    super();
-    this.stripeClient = stripeClient;
-    this.logTreeItems = [];
-    this.logsStdoutStream = null;
-    this.logsStderrStream = null;
-    this.viewState = ViewState.Idle;
+    super(stripeClient, CLICommand.LogsTail);
   }
 
-  startLogsStreaming = async () => {
-    if (this.viewState === ViewState.Idle) {
-      this.setViewState(ViewState.Loading);
-      try {
-        await this.setupStreams();
-      } catch (e) {
-        window.showErrorMessage(e.message);
-        this.stopLogsStreaming();
-      }
-    }
-  };
-
-  stopLogsStreaming = () => {
-    this.cleanupStreams();
-    this.setViewState(ViewState.Idle);
-  };
-
   buildTree(): Promise<StripeTreeItem[]> {
-    const streamingControlItemArgs = (() => {
-      switch (this.viewState) {
-        case ViewState.Idle:
-          return {
-            label: 'Start streaming API logs',
-            command: 'startLogsStreaming',
-            iconId: 'play-circle',
-          };
-        case ViewState.Loading:
-          return {
-            label: 'Starting streaming API logs...',
-            command: 'stopLogsStreaming',
-            iconId: 'loading',
-          };
-        case ViewState.Streaming:
-          return {
-            label: 'Stop streaming API logs',
-            command: 'stopLogsStreaming',
-            iconId: 'stop-circle',
-          };
-      }
-    })();
+    const treeItems = [
+      this.getStreamingControlItem('API logs', 'startLogsStreaming', 'stopLogsStreaming'),
+    ];
 
-    const streamingControlItem = this.createItemWithCommand(streamingControlItemArgs);
-
-    const treeItems = [streamingControlItem];
-
-    if (this.logTreeItems.length > 0) {
+    if (this.streamingTreeItems.length > 0) {
       const logsStreamRootItem = new StripeTreeItem('Recent logs');
-      logsStreamRootItem.children = this.logTreeItems;
+      logsStreamRootItem.children = this.streamingTreeItems;
       logsStreamRootItem.expand();
       treeItems.push(logsStreamRootItem);
     }
@@ -108,23 +48,7 @@ export class StripeLogsViewProvider extends StripeTreeViewDataProvider {
     return Promise.resolve(treeItems);
   }
 
-  private createItemWithCommand({
-    label,
-    command,
-    iconId,
-  }: {
-    label: string;
-    command?: string;
-    iconId?: string;
-  }) {
-    const item = new StripeTreeItem(label, {
-      commandString: command,
-      iconPath: iconId ? new ThemeIcon(iconId) : undefined,
-    });
-    return item;
-  }
-
-  private async setupStreams() {
+  async createStreamProcess(): Promise<ChildProcess> {
     const stripeLogsTailProcess = await this.stripeClient.getOrCreateCLIProcess(
       CLICommand.LogsTail,
       ['--format', 'JSON'],
@@ -132,90 +56,31 @@ export class StripeLogsViewProvider extends StripeTreeViewDataProvider {
     if (!stripeLogsTailProcess) {
       throw new Error('Failed to start `stripe logs tail` process');
     }
-
-    stripeLogsTailProcess.on('exit', this.stopLogsStreaming);
-
-    /**
-     * The CLI lets you know that streaming is ready via stderr. In the happy path:
-     *
-     * $ stripe logs tail
-     * Getting ready...
-     * Ready! You're now waiting to receive API request logs (^C to quit)
-     *
-     * We interpret any other message as an error.
-     */
-    if (!this.logsStderrStream) {
-      this.logsStderrStream = new stream.Writable({
-        write: (chunk, _, callback) => {
-          if (chunk.includes('Ready!')) {
-            this.setViewState(ViewState.Streaming);
-          } else if (!chunk.includes('Getting ready')) {
-            window.showErrorMessage(chunk);
-            this.stopLogsStreaming();
-          }
-          callback();
-        },
-        decodeStrings: false,
-      });
-      stripeLogsTailProcess.stderr
-        .setEncoding('utf8')
-        .pipe(new LineStream())
-        .pipe(this.logsStderrStream);
-    }
-
-    if (!this.logsStdoutStream) {
-      this.logsStdoutStream = new stream.Writable({
-        write: (chunk, _, callback) => {
-          try {
-            const object = JSON.parse(chunk);
-            if (isLogObject(object)) {
-              const label = `[${object.status}] ${object.method} ${object.url} [${object.request_id}]`;
-              const logTreeItem = new StripeTreeItem(label, {
-                commandString: 'openDashboardLogFromTreeItem',
-                contextValue: 'logItem',
-                tooltip: unixToLocaleStringTZ(object.created_at),
-              });
-              logTreeItem.metadata = {
-                id: object.request_id,
-              };
-              this.insertLog(logTreeItem);
-            }
-          } catch {}
-          callback();
-        },
-        decodeStrings: false,
-      });
-      stripeLogsTailProcess.stdout
-        .setEncoding('utf8')
-        .pipe(new LineStream())
-        .pipe(this.logsStdoutStream);
-    }
+    return stripeLogsTailProcess;
   }
 
-  private cleanupStreams = () => {
-    if (this.logsStdoutStream) {
-      this.logsStdoutStream.destroy();
-      this.logsStdoutStream = null;
+  streamReady(chunk: any): boolean {
+    return chunk.includes('Ready!');
+  }
+
+  streamLoading(chunk: any): boolean {
+    return chunk.includes('Getting ready');
+  }
+
+  createTreeItem(chunk: any): StripeTreeItem | null {
+    const object = JSON.parse(chunk);
+    if (isLogObject(object)) {
+      const label = `[${object.status}] ${object.method} ${object.url} [${object.request_id}]`;
+      const logTreeItem = new StripeTreeItem(label, {
+        commandString: 'openDashboardLogFromTreeItem',
+        contextValue: 'logItem',
+        tooltip: unixToLocaleStringTZ(object.created_at),
+      });
+      logTreeItem.metadata = {
+        id: object.request_id,
+      };
+      return logTreeItem;
     }
-    if (this.logsStderrStream) {
-      this.logsStderrStream.destroy();
-      this.logsStderrStream = null;
-    }
-    this.stripeClient.endCLIProcess(CLICommand.LogsTail);
-  };
-
-  private debouncedRefresh = debounce(
-    this.refresh.bind(this),
-    StripeLogsViewProvider.REFRESH_DEBOUNCE_MILLIS,
-  );
-
-  private insertLog = (logTreeItem: StripeTreeItem) => {
-    this.logTreeItems.unshift(logTreeItem);
-    this.debouncedRefresh();
-  };
-
-  private setViewState(viewState: ViewState) {
-    this.viewState = viewState;
-    this.refresh();
+    return null;
   }
 }

--- a/src/stripeLogsView.ts
+++ b/src/stripeLogsView.ts
@@ -66,7 +66,7 @@ export class StripeLogsViewProvider extends StreamingViewDataProvider {
     return chunk.includes('Getting ready');
   }
 
-  createTreeItem(chunk: any): StripeTreeItem | null {
+  createStreamTreeItem(chunk: any): StripeTreeItem | null {
     const object = JSON.parse(chunk);
     if (isLogObject(object)) {
       const label = `[${object.status}] ${object.method} ${object.url} [${object.request_id}]`;

--- a/src/stripeLogsView.ts
+++ b/src/stripeLogsView.ts
@@ -4,7 +4,6 @@ import {StreamingViewDataProvider} from './stripeStreamingView';
 import {StripeTreeItem} from './stripeTreeItem';
 import {unixToLocaleStringTZ} from './utils';
 
-// Log object should have an isObject and method for how to create a label.
 type LogObject = {
   status: number;
   method: string;

--- a/src/stripeStreamingView.ts
+++ b/src/stripeStreamingView.ts
@@ -36,7 +36,7 @@ export abstract class StreamingViewDataProvider extends StripeTreeViewDataProvid
     this.viewState = ViewState.Idle;
   }
 
-  starStreaming = async () => {
+  startStreaming = async () => {
     if (this.viewState === ViewState.Idle) {
       this.setViewState(ViewState.Loading);
       try {
@@ -54,7 +54,7 @@ export abstract class StreamingViewDataProvider extends StripeTreeViewDataProvid
   };
 
   protected getStreamingControlItem(
-    name: string,
+    viewName: string,
     startCommand: string,
     stopCommand: string,
   ): StripeTreeItem {
@@ -62,19 +62,19 @@ export abstract class StreamingViewDataProvider extends StripeTreeViewDataProvid
       switch (this.viewState) {
         case ViewState.Idle:
           return {
-            label: `Start streaming ${name}`,
+            label: `Start streaming ${viewName}`,
             command: startCommand,
             iconId: 'play-circle',
           };
         case ViewState.Loading:
           return {
-            label: `Starting streaming ${name} ...`,
+            label: `Starting streaming ${viewName} ...`,
             command: stopCommand,
             iconId: 'loading',
           };
         case ViewState.Streaming:
           return {
-            label: `Stop streaming ${name}`,
+            label: `Stop streaming ${viewName}`,
             command: stopCommand,
             iconId: 'stop-circle',
           };

--- a/src/stripeStreamingView.ts
+++ b/src/stripeStreamingView.ts
@@ -124,7 +124,7 @@ export abstract class StreamingViewDataProvider extends StripeTreeViewDataProvid
       this.stdoutStream = new stream.Writable({
         write: (chunk, _, callback) => {
           try {
-            const object = this.createTreeItem(chunk);
+            const object = this.createStreamTreeItem(chunk);
             if (object) {
               this.insertItem(object);
             }
@@ -147,7 +147,7 @@ export abstract class StreamingViewDataProvider extends StripeTreeViewDataProvid
   abstract streamLoading(chunk: any): boolean;
 
   // Tell us how to process the chunk into a tree item.
-  abstract createTreeItem(chunk: any): StripeTreeItem | null;
+  abstract createStreamTreeItem(chunk: any): StripeTreeItem | null;
 
   private cleanupStreams = () => {
     if (this.stdoutStream) {

--- a/src/stripeStreamingView.ts
+++ b/src/stripeStreamingView.ts
@@ -1,0 +1,175 @@
+import {CLICommand, StripeClient} from './stripeClient';
+import {ThemeIcon, window} from 'vscode';
+import {ChildProcess} from 'child_process';
+import {LineStream} from 'byline';
+import {StripeTreeItem} from './stripeTreeItem';
+import {StripeTreeViewDataProvider} from './stripeTreeViewDataProvider';
+import {debounce} from './utils';
+import stream from 'stream';
+
+enum ViewState {
+  Idle,
+  Loading,
+  Streaming,
+}
+
+const REFRESH_DEBOUNCE_MILLIS = 1000;
+
+/**
+ * This is an abstract class for TreeViews with streaming tree items.
+ */
+export abstract class StreamingViewDataProvider extends StripeTreeViewDataProvider {
+  protected stripeClient: StripeClient;
+  protected streamingTreeItems: StripeTreeItem[];
+  private streamCommand: CLICommand;
+  private viewState: ViewState;
+  private stdoutStream: stream.Writable | null;
+  private stderrStream: stream.Writable | null;
+
+  constructor(stripeClient: StripeClient, streamCommand: CLICommand) {
+    super();
+    this.stripeClient = stripeClient;
+    this.streamCommand = streamCommand;
+    this.streamingTreeItems = [];
+    this.stdoutStream = null;
+    this.stderrStream = null;
+    this.viewState = ViewState.Idle;
+  }
+
+  starStreaming = async () => {
+    if (this.viewState === ViewState.Idle) {
+      this.setViewState(ViewState.Loading);
+      try {
+        await this.setupStreams();
+      } catch (e) {
+        window.showErrorMessage(e.message);
+        this.stopStreaming();
+      }
+    }
+  };
+
+  stopStreaming = () => {
+    this.cleanupStreams();
+    this.setViewState(ViewState.Idle);
+  };
+
+  protected getStreamingControlItem(
+    name: string,
+    startCommand: string,
+    stopCommand: string,
+  ): StripeTreeItem {
+    const streamingControlItemArgs = (() => {
+      switch (this.viewState) {
+        case ViewState.Idle:
+          return {
+            label: `Start streaming ${name}`,
+            command: startCommand,
+            iconId: 'play-circle',
+          };
+        case ViewState.Loading:
+          return {
+            label: `Starting streaming ${name} ...`,
+            command: stopCommand,
+            iconId: 'loading',
+          };
+        case ViewState.Streaming:
+          return {
+            label: `Stop streaming ${name}`,
+            command: stopCommand,
+            iconId: 'stop-circle',
+          };
+      }
+    })();
+
+    return this.createItemWithCommand(streamingControlItemArgs);
+  }
+
+  private createItemWithCommand({
+    label,
+    command,
+    iconId,
+  }: {
+    label: string;
+    command?: string;
+    iconId?: string;
+  }) {
+    const item = new StripeTreeItem(label, {
+      commandString: command,
+      iconPath: iconId ? new ThemeIcon(iconId) : undefined,
+    });
+    return item;
+  }
+
+  private async setupStreams() {
+    const tailProcess = await this.createStreamProcess();
+    tailProcess.on('exit', this.stopStreaming);
+
+    if (!this.stderrStream) {
+      this.stderrStream = new stream.Writable({
+        write: (chunk, _, callback) => {
+          if (this.streamReady(chunk)) {
+            this.setViewState(ViewState.Streaming);
+          } else if (!this.streamLoading(chunk)) {
+            window.showErrorMessage(chunk);
+            this.stopStreaming();
+          }
+          callback();
+        },
+        decodeStrings: false,
+      });
+      tailProcess.stderr.setEncoding('utf8').pipe(new LineStream()).pipe(this.stderrStream);
+    }
+
+    if (!this.stdoutStream) {
+      this.stdoutStream = new stream.Writable({
+        write: (chunk, _, callback) => {
+          try {
+            const object = this.createTreeItem(chunk);
+            if (object) {
+              this.insertItem(object);
+            }
+          } catch {}
+          callback();
+        },
+        decodeStrings: false,
+      });
+      tailProcess.stdout.setEncoding('utf8').pipe(new LineStream()).pipe(this.stdoutStream);
+    }
+  }
+
+  // Tell us how to start the process
+  abstract createStreamProcess(): Promise<ChildProcess>;
+
+  // Tell us how we can tell when the process is ready
+  abstract streamReady(chunk: any): boolean;
+
+  // Tell us how we can tell if the stream is still loading
+  abstract streamLoading(chunk: any): boolean;
+
+  // Tell us how to process the chunk into a tree item.
+  abstract createTreeItem(chunk: any): StripeTreeItem | null;
+
+  private cleanupStreams = () => {
+    if (this.stdoutStream) {
+      this.stdoutStream.destroy();
+      this.stdoutStream = null;
+    }
+    if (this.stderrStream) {
+      this.stderrStream.destroy();
+      this.stderrStream = null;
+    }
+    this.stripeClient.endCLIProcess(this.streamCommand);
+  };
+
+  private debouncedRefresh = debounce(this.refresh.bind(this), REFRESH_DEBOUNCE_MILLIS);
+
+  private insertItem = (treeItem: StripeTreeItem) => {
+    this.streamingTreeItems.unshift(treeItem);
+    this.debouncedRefresh();
+  };
+
+  private setViewState(viewState: ViewState) {
+    this.viewState = viewState;
+    this.refresh();
+  }
+}

--- a/src/test/suite/utils.test.ts
+++ b/src/test/suite/utils.test.ts
@@ -132,4 +132,20 @@ suite('Utils', () => {
       assert.deepStrictEqual(item, []);
     });
   });
+
+  suite('unixToLocaleStringTZ', () => {
+    const timestamp = 1614896075; // March 4, 2021, 2:14:35 PM PST
+
+    [
+      ['en', '3/4/2021, 2:14:35 PM PST'],
+      ['en-gb', '04/03/2021, 14:14:35 GMT-8'],
+      ['ja-jp', '2021/3/4 14:14:35 GMT-8'],
+    ].forEach(([lang, expectedLocaleString]) => {
+      test(`works in ${lang}`, () => {
+        sandbox.stub(vscode.env, 'language').value(lang);
+        const actualLocaleString = utils.unixToLocaleStringTZ(timestamp);
+        assert.strictEqual(actualLocaleString, expectedLocaleString);
+      });
+    });
+  });
 });

--- a/src/test/suite/utils.test.ts
+++ b/src/test/suite/utils.test.ts
@@ -132,20 +132,4 @@ suite('Utils', () => {
       assert.deepStrictEqual(item, []);
     });
   });
-
-  suite('unixToLocaleStringTZ', () => {
-    const timestamp = 1614896075; // March 4, 2021, 2:14:35 PM PST
-
-    [
-      ['en', '3/4/2021, 2:14:35 PM PST'],
-      ['en-gb', '04/03/2021, 14:14:35 GMT-8'],
-      ['ja-jp', '2021/3/4 14:14:35 GMT-8'],
-    ].forEach(([lang, expectedLocaleString]) => {
-      test(`works in ${lang}`, () => {
-        sandbox.stub(vscode.env, 'language').value(lang);
-        const actualLocaleString = utils.unixToLocaleStringTZ(timestamp);
-        assert.strictEqual(actualLocaleString, expectedLocaleString);
-      });
-    });
-  });
 });


### PR DESCRIPTION
Moving out streaming management components from the stripeLogView file to an abstract class called StreamingViewDataProvider. The goal was to move the stream and state management to the abstract class, but not so strictly that we wouldn't be able to support future usecases.

This is a precursor to adding events streaming.

## Testing
Manually tested the log streaming functionality. 