### PR TITLE
Refactor activate function

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -3,8 +3,8 @@ import * as vscode from 'vscode';
 import {getExtensionInfo, showQuickPickWithItems, showQuickPickWithValues} from './utils';
 import {getRecentEvents, recordEvent} from './stripeWorkspaceState';
 import osName = require('os-name');
-import {StripeEventsDataProvider} from './stripeEventsView';
-import {StripeLogsDataProvider} from './stripeLogsView';
+import {StripeEventsViewProvider} from './stripeEventsView';
+import {StripeLogsViewProvider} from './stripeLogsView';
 import {StripeTerminal} from './stripeTerminal';
 import {StripeTreeItem} from './stripeTreeItem';
 import {Telemetry} from './telemetry';
@@ -122,14 +122,14 @@ export class Commands {
     this.terminal.execute('listen', [...forwardToFlag, ...forwardConnectToFlag, ...eventsFlag]);
   };
 
-  startLogsStreaming = (stripeLogsDataProvider: StripeLogsDataProvider) => {
+  startLogsStreaming = (stripeLogsViewProvider: StripeLogsViewProvider) => {
     this.telemetry.sendEvent('startLogsStreaming');
-    stripeLogsDataProvider.startLogsStreaming();
+    stripeLogsViewProvider.startLogsStreaming();
   };
 
-  stopLogsStreaming = (stripeLogsDataProvider: StripeLogsDataProvider) => {
+  stopLogsStreaming = (stripeLogsViewProvider: StripeLogsViewProvider) => {
     this.telemetry.sendEvent('stopLogsStreaming');
-    stripeLogsDataProvider.stopLogsStreaming();
+    stripeLogsViewProvider.stopLogsStreaming();
   };
 
   startLogin = () => {
@@ -212,7 +212,7 @@ export class Commands {
     );
   };
 
-  refreshEventsList = (stripeEventsViewProvider: StripeEventsDataProvider) => {
+  refreshEventsList = (stripeEventsViewProvider: StripeEventsViewProvider) => {
     this.telemetry.sendEvent('refreshEventsList');
     stripeEventsViewProvider.refresh();
   };

--- a/src/stripeDashboardView.ts
+++ b/src/stripeDashboardView.ts
@@ -2,7 +2,7 @@ import {StripeTreeItem} from './stripeTreeItem';
 import {StripeTreeViewDataProvider} from './stripeTreeViewDataProvider';
 import {ThemeIcon} from 'vscode';
 
-export class StripeDashboardViewDataProvider extends StripeTreeViewDataProvider {
+export class StripeDashboardViewProvider extends StripeTreeViewDataProvider {
   buildTree(): Promise<StripeTreeItem[]> {
     const items = [];
 

--- a/src/stripeEventsView.ts
+++ b/src/stripeEventsView.ts
@@ -4,7 +4,7 @@ import {StripeTreeViewDataProvider} from './stripeTreeViewDataProvider';
 import {ThemeIcon} from 'vscode';
 import {unixToLocaleStringTZ} from './utils';
 
-export class StripeEventsDataProvider extends StripeTreeViewDataProvider {
+export class StripeEventsViewProvider extends StripeTreeViewDataProvider {
   stripeClient: StripeClient;
 
   constructor(stripeClient: StripeClient) {

--- a/src/stripeHelpView.ts
+++ b/src/stripeHelpView.ts
@@ -2,7 +2,7 @@ import {StripeTreeItem} from './stripeTreeItem';
 import {StripeTreeViewDataProvider} from './stripeTreeViewDataProvider';
 import {ThemeIcon} from 'vscode';
 
-export class StripeHelpViewDataProvider extends StripeTreeViewDataProvider {
+export class StripeHelpViewProvider extends StripeTreeViewDataProvider {
   buildTree(): Promise<StripeTreeItem[]> {
     const items = [];
 

--- a/src/stripeLogsView.ts
+++ b/src/stripeLogsView.ts
@@ -35,7 +35,7 @@ export const isLogObject = (object: any): object is LogObject => {
   );
 };
 
-export class StripeLogsDataProvider extends StripeTreeViewDataProvider {
+export class StripeLogsViewProvider extends StripeTreeViewDataProvider {
   private static readonly REFRESH_DEBOUNCE_MILLIS = 1000;
 
   private stripeClient: StripeClient;
@@ -206,7 +206,7 @@ export class StripeLogsDataProvider extends StripeTreeViewDataProvider {
 
   private debouncedRefresh = debounce(
     this.refresh.bind(this),
-    StripeLogsDataProvider.REFRESH_DEBOUNCE_MILLIS,
+    StripeLogsViewProvider.REFRESH_DEBOUNCE_MILLIS,
   );
 
   private insertLog = (logTreeItem: StripeTreeItem) => {


### PR DESCRIPTION
The `activate` function is getting long, and some of the variable names are inconsistent, which adds friction when we want to add new features. This PR renames some variables for consistency, removes some redundant comments, and refactors how commands are registered.

Verified manually and with existing tests.