### PR TITLE
Prompt CLI installation in modal

### DIFF
--- a/src/stripeClient.ts
+++ b/src/stripeClient.ts
@@ -65,15 +65,14 @@ export class StripeClient {
   }
 
   private async promptInstall() {
-    const actionText = 'Read instructions on how to install Stripe CLI';
-    const returnValue = await vscode.window.showErrorMessage(
+    const openDocsOption = 'Read instructions on how to install Stripe CLI';
+    const selectedOption = await vscode.window.showErrorMessage(
       'Welcome! Stripe is using the Stripe CLI behind the scenes, and requires it to be installed on your machine',
-      {},
-      ...[actionText],
+      {modal: true},
+      ...[openDocsOption],
     );
-
-    if (returnValue === actionText) {
-      vscode.env.openExternal(vscode.Uri.parse('https://stripe.com/docs/stripe-cli'));
+    if (selectedOption === openDocsOption) {
+      vscode.env.openExternal(vscode.Uri.parse('https://stripe.com/docs/stripe-cli#install'));
     }
   }
 

--- a/src/test/suite/stripeClient.test.ts
+++ b/src/test/suite/stripeClient.test.ts
@@ -72,7 +72,7 @@ suite('stripeClient', () => {
         assert.strictEqual(cliPath, null);
         assert.deepStrictEqual(showErrorMessageSpy.args[0], [
           'Welcome! Stripe is using the Stripe CLI behind the scenes, and requires it to be installed on your machine',
-          {},
+          {modal: true},
           'Read instructions on how to install Stripe CLI',
         ]);
       });


### PR DESCRIPTION
Show a more prominent message to install the CLI. Deep-link to https://stripe.com/docs/stripe-cli#install. Rename some variables for clarity.

Before:
![Screen Shot 2021-03-15 at 5 06 01 PM](https://user-images.githubusercontent.com/71457708/111236702-bf96c700-85b0-11eb-97f4-1e17c214c2a3.png)

After:
![Screen Shot 2021-03-12 at 3 05 38 PM](https://user-images.githubusercontent.com/71457708/111236664-aa219d00-85b0-11eb-9978-147ad9bac138.png)

Part of #187.

Updated existing test and manually verified.