### PR TITLE
Detect processor arch and fork on that for darwin

### DIFF
--- a/src/stripeClient.ts
+++ b/src/stripeClient.ts
@@ -171,9 +171,12 @@ export class StripeClient {
     const defaultInstallPath = (() => {
       const osType: OSType = getOSType();
       switch (osType) {
-        case OSType.macOS:
-          // HomeBrew install path on macOS
+        case OSType.macOSintel:
+          // HomeBrew install path on macOS Intel
           return '/usr/local/bin/stripe';
+        case OSType.macOSarm:
+          // ARM installs go into a separate path
+          return '/opt/homebrew/bin/stripe'
         case OSType.linux:
           // apt-get install path on ubuntu + yum install path on centOS
           return '/usr/local/bin/stripe';

--- a/src/test/suite/stripeClient.test.ts
+++ b/src/test/suite/stripeClient.test.ts
@@ -25,7 +25,8 @@ suite('stripeClient', () => {
     suite('with default CLI install path', () => {
       const osPathPairs: [utils.OSType, string][] = [
         [utils.OSType.linux, '/usr/local/bin/stripe'],
-        [utils.OSType.macOS, '/usr/local/bin/stripe'],
+        [utils.OSType.macOSintel, '/usr/local/bin/stripe'],
+        [utils.OSType.macOSarm, '/opt/homebrew/bin/stripe'],
         [utils.OSType.windows, 'scoop/shims/stripe.exe'],
       ];
       const resolvedPath = '/resolved/path/to/stripe';
@@ -79,7 +80,7 @@ suite('stripeClient', () => {
     });
 
     suite('with custom CLI install path', () => {
-      const osTypes = [utils.OSType.linux, utils.OSType.macOS, utils.OSType.windows];
+      const osTypes = [utils.OSType.linux, utils.OSType.macOSintel, utils.OSType.macOSarm, utils.OSType.windows];
       const customPath = '/foo/bar/baz';
       const resolvedPath = '/resolved/path/to/stripe';
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,8 @@
 import * as vscode from 'vscode';
 
 export enum OSType {
-  macOS = 'macOS',
+  macOSintel = 'macOSintel',
+  macOSarm = 'macOSarm',
   linux = 'linux',
   unknown = 'unknown',
   windows = 'windows',
@@ -18,11 +19,16 @@ export function getExtensionInfo() {
 
 export function getOSType(): OSType {
   const platform: string = process.platform;
+  const arch: string = process.arch;
 
   if (/^win/.test(platform)) {
     return OSType.windows;
   } else if (/^darwin/.test(platform)) {
-    return OSType.macOS;
+    if (arch === 'arm64') {
+      return OSType.macOSarm;
+    }
+
+    return OSType.macOSintel;
   } else if (/^linux/.test(platform)) {
     return OSType.linux;
   } else {


### PR DESCRIPTION
r? @vcheung-stripe @gracegoo-stripe 
cc @jhstrauss

With the help from #171, this should work for M1 macs. `process.arch` will return `arm64` (https://nodejs.org/api/process.html#process_process_arch) on the new devices instead of `x64`.