### PR TITLE
Adding event streaming

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,10 +50,11 @@
     "onCommand:stripe.openReportIssue",
     "onCommand:stripe.openDocs",
     "onCommand:stripe.openSurvey",
-    "onCommand:stripe.refreshEventsList",
     "onCommand:stripe.startLogsStreaming",
     "onCommand:stripe.stopLogsStreaming",
     "onCommand:stripe.clearRecentLogs",
+    "onCommand:stripe.startEventsStreaming",
+    "onCommand:stripe.stopEventsStreaming",
     "onLanguage:typescript",
     "onLanguage:javascript",
     "onLanguage:csharp",
@@ -99,13 +100,23 @@
       },
       {
         "category": "Stripe",
+        "command": "stripe.startEventsStreaming",
+        "title": "Start streaming Events"
+      },
+      {
+        "category": "Stripe",
+        "command": "stripe.stopEventsStreaming",
+        "title": "Stop streaming Events"
+      },
+      {
+        "category": "Stripe",
         "command": "stripe.startLogsStreaming",
-        "title": "Start API logs streaming"
+        "title": "Start streaming API logs "
       },
       {
         "category": "Stripe",
         "command": "stripe.stopLogsStreaming",
-        "title": "Stop API logs streaming"
+        "title": "Stop streaming API logs"
       },
       {
         "category": "Stripe",
@@ -151,12 +162,6 @@
         "category": "Stripe",
         "command": "stripe.openEventDetails",
         "title": "Open read-only document with a specific event"
-      },
-      {
-        "category": "Stripe",
-        "command": "stripe.refreshEventsList",
-        "title": "Refresh events list",
-        "icon": "$(refresh)"
       },
       {
         "category": "Stripe",
@@ -212,11 +217,6 @@
     },
     "menus": {
       "view/title": [
-        {
-          "command": "stripe.refreshEventsList",
-          "when": "view == stripeEventsView",
-          "group": "navigation"
-        },
         {
           "command": "stripe.clearRecentLogs",
           "when": "view == stripeLogsView",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -122,6 +122,16 @@ export class Commands {
     this.terminal.execute('listen', [...forwardToFlag, ...forwardConnectToFlag, ...eventsFlag]);
   };
 
+  startEventsStreaming = (stripeEventsViewProvider: StripeEventsViewProvider) => {
+    this.telemetry.sendEvent('startEventsStreaming');
+    stripeEventsViewProvider.startStreaming();
+  };
+
+  stopEventsStreaming = (stripeEventsViewProvider: StripeEventsViewProvider) => {
+    this.telemetry.sendEvent('stopEventsStreaming');
+    stripeEventsViewProvider.stopStreaming();
+  };
+
   startLogsStreaming = (stripeLogsViewProvider: StripeLogsViewProvider) => {
     this.telemetry.sendEvent('startLogsStreaming');
     stripeLogsViewProvider.startStreaming();
@@ -217,11 +227,6 @@ export class Commands {
     );
   };
 
-  refreshEventsList = (stripeEventsViewProvider: StripeEventsViewProvider) => {
-    this.telemetry.sendEvent('refreshEventsList');
-    stripeEventsViewProvider.refresh();
-  };
-
   openTriggerEvent = async (extensionContext: vscode.ExtensionContext) => {
     this.telemetry.sendEvent('openTriggerEvent');
     const events = this.buildTriggerEventsList(this.supportedEvents, extensionContext);
@@ -229,11 +234,6 @@ export class Commands {
     if (eventName) {
       this.terminal.execute('trigger', [eventName]);
       recordEvent(extensionContext, eventName);
-
-      // Trigger events refresh after 5s as we don't have a way to know when it has finished.
-      setTimeout(() => {
-        vscode.commands.executeCommand('stripe.refreshEventsList');
-      }, 5000);
     }
   };
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -103,8 +103,15 @@ export function activate(this: any, context: ExtensionContext) {
     ['stripe.openTriggerEvent', () => stripeCommands.openTriggerEvent(context)],
     ['stripe.openWebhooksDebugConfigure', stripeCommands.openWebhooksDebugConfigure],
     ['stripe.openWebhooksListen', stripeCommands.openWebhooksListen],
-    ['stripe.refreshEventsList', () => stripeCommands.refreshEventsList(stripeEventsViewProvider)],
     ['stripe.resendEvent', stripeCommands.resendEvent],
+    [
+      'stripe.startEventsStreaming',
+      () => stripeCommands.startEventsStreaming(stripeEventsViewProvider),
+    ],
+    [
+      'stripe.stopEventsStreaming',
+      () => stripeCommands.stopEventsStreaming(stripeEventsViewProvider),
+    ],
     ['stripe.startLogsStreaming', () => stripeCommands.startLogsStreaming(stripeLogsViewProvider)],
     ['stripe.stopLogsStreaming', () => stripeCommands.stopLogsStreaming(stripeLogsViewProvider)],
     ['stripe.clearRecentLogs', () => stripeCommands.clearRecentLogs(stripeLogsViewProvider)],

--- a/src/stripeClient.ts
+++ b/src/stripeClient.ts
@@ -15,10 +15,12 @@ const MIN_CLI_VERSION = 'v1.5.12';
 
 export enum CLICommand {
   LogsTail,
+  Listen,
 }
 
 const cliCommandToArgsMap: Map<CLICommand, string[]> = new Map([
   [CLICommand.LogsTail, ['logs', 'tail']],
+  [CLICommand.Listen, ['listen']],
 ]);
 
 export class StripeClient {

--- a/src/stripeEventsView.ts
+++ b/src/stripeEventsView.ts
@@ -65,14 +65,14 @@ export class StripeEventsViewProvider extends StreamingViewDataProvider {
     return Promise.resolve(items);
   }
   async createStreamProcess(): Promise<ChildProcess> {
-    const stripeListenTailProcess = await this.stripeClient.getOrCreateCLIProcess(
-      CLICommand.Listen,
-      ['--format', 'JSON'],
-    );
-    if (!stripeListenTailProcess) {
+    const stripeListenProcess = await this.stripeClient.getOrCreateCLIProcess(CLICommand.Listen, [
+      '--format',
+      'JSON',
+    ]);
+    if (!stripeListenProcess) {
       throw new Error('Failed to start `stripe listen` process');
     }
-    return stripeListenTailProcess;
+    return stripeListenProcess;
   }
 
   streamReady(chunk: any): boolean {

--- a/src/stripeEventsView.ts
+++ b/src/stripeEventsView.ts
@@ -1,41 +1,55 @@
-import {StripeClient} from './stripeClient';
+import {CLICommand, StripeClient} from './stripeClient';
+import {ChildProcess} from 'child_process';
+import {StreamingViewDataProvider} from './stripeStreamingView';
 import {StripeTreeItem} from './stripeTreeItem';
-import {StripeTreeViewDataProvider} from './stripeTreeViewDataProvider';
 import {ThemeIcon} from 'vscode';
 import {unixToLocaleStringTZ} from './utils';
 
-export class StripeEventsViewProvider extends StripeTreeViewDataProvider {
-  stripeClient: StripeClient;
+type EventObject = {
+  created: number;
+  type: string;
+  id: string;
+};
 
-  constructor(stripeClient: StripeClient) {
-    super();
-    this.stripeClient = stripeClient;
+export const isEventObject = (object: any): object is EventObject => {
+  if (!object || typeof object !== 'object') {
+    return false;
   }
 
-  async buildTree(): Promise<StripeTreeItem[]> {
-    const eventsItem = new StripeTreeItem('Recent events');
-    eventsItem.expand();
+  if (object.object !== 'event') {
+    return false;
+  }
 
-    try {
-      const events = await this.stripeClient.getEvents();
+  const possibleEventObject = object as EventObject;
+  return (
+    typeof possibleEventObject.created === 'number' &&
+    typeof possibleEventObject.type === 'string' &&
+    typeof possibleEventObject.id === 'string'
+  );
+};
 
-      if (events.data) {
-        events.data.forEach((event: any) => {
-          const title = event.type;
-          const eventItem = new StripeTreeItem(title, {
-            commandString: 'openEventDetails',
-            contextValue: 'eventItem',
-            tooltip: unixToLocaleStringTZ(event.created),
-          });
-          eventItem.metadata = {
-            type: event.type,
-            id: event.id,
-          };
-          eventsItem.addChild(eventItem);
-        });
-      }
-    } catch (e) {}
+export class StripeEventsViewProvider extends StreamingViewDataProvider {
+  constructor(stripeClient: StripeClient) {
+    super(stripeClient, CLICommand.Listen);
+  }
 
+  buildEventsTree(): StripeTreeItem[] {
+    const treeItems = [
+      this.getStreamingControlItem('Events', 'startEventsStreaming', 'stopEventsStreaming'),
+    ];
+
+    if (this.streamingTreeItems.length > 0) {
+      const eventsStreamRootItem = new StripeTreeItem('Recent events');
+      eventsStreamRootItem.children = this.streamingTreeItems;
+      eventsStreamRootItem.expand();
+      treeItems.push(eventsStreamRootItem);
+    }
+
+    return treeItems;
+  }
+
+  buildTree(): Promise<StripeTreeItem[]> {
+    const eventsItem = this.buildEventsTree();
     const triggerEventItem = new StripeTreeItem('Trigger new event', {
       commandString: 'openTriggerEvent',
       iconPath: new ThemeIcon('add'),
@@ -46,9 +60,46 @@ export class StripeEventsViewProvider extends StripeTreeViewDataProvider {
       iconPath: new ThemeIcon('terminal'),
     });
 
-    var items = [triggerEventItem, webhooksListenItem];
-    items.push(eventsItem);
+    const items = [triggerEventItem, webhooksListenItem, ...eventsItem];
 
-    return items;
+    return Promise.resolve(items);
+  }
+  async createStreamProcess(): Promise<ChildProcess> {
+    const stripeListenTailProcess = await this.stripeClient.getOrCreateCLIProcess(
+      CLICommand.Listen,
+      ['--format', 'JSON'],
+    );
+    if (!stripeListenTailProcess) {
+      throw new Error('Failed to start `stripe listen` process');
+    }
+    return stripeListenTailProcess;
+  }
+
+  streamReady(chunk: any): boolean {
+    return chunk.includes('Ready!');
+  }
+
+  streamLoading(chunk: any): boolean {
+    return chunk.includes('Getting ready');
+  }
+
+  createStreamTreeItem(chunk: any): StripeTreeItem | null {
+    const object = JSON.parse(chunk);
+    if (isEventObject(object)) {
+      const label = object.type;
+      const event = new StripeTreeItem(label, {
+        commandString: 'openEventDetails',
+        contextValue: 'eventItem',
+        tooltip: unixToLocaleStringTZ(object.created),
+      });
+
+      event.metadata = {
+        type: object.type,
+        id: object.id,
+      };
+
+      return event;
+    }
+    return null;
   }
 }


### PR DESCRIPTION
Replacing the recent events section with events streaming. Also got rid of the refreshing of events since that is no longer relevant. 

This depends on a specific release of the CLI: https://github.com/stripe/stripe-cli/pull/615. In fact, I think this is a good opportunity for us to add the [min version](https://github.com/stripe/vscode-stripe/issues/184) feature first before merging this PR in. 


This PR does not address the `openEventDetails` action. That action still uses the stripeClient to make another call to grab the event details from the id. I'll follow this PR up with another that stores the entire event object  in the tree so that `openEventDetails` does not need to use the CLI to fetch that info again. 

Before:
![Screen Shot 2021-03-18 at 3 47 14 PM](https://user-images.githubusercontent.com/75757829/111707405-375b3080-8801-11eb-8f69-e0e08ef48410.png)

After:
![Screen Shot 2021-03-18 at 3 46 34 PM](https://user-images.githubusercontent.com/75757829/111707354-201c4300-8801-11eb-96d4-32ed2791b6cb.png)

