### PR TITLE
Add clear recent events functionality and replacing event details tex…

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "onCommand:stripe.startLogsStreaming",
     "onCommand:stripe.stopLogsStreaming",
     "onCommand:stripe.clearRecentLogs",
+    "onCommand:stripe.clearRecentEvents",
     "onCommand:stripe.startEventsStreaming",
     "onCommand:stripe.stopEventsStreaming",
     "onLanguage:typescript",
@@ -171,6 +172,12 @@
       },
       {
         "category": "Stripe",
+        "command": "stripe.clearRecentEvents",
+        "title": "Clear recent events",
+        "icon": "$(clear-all)"
+      },
+      {
+        "category": "Stripe",
         "command": "stripe.openTriggerEvent",
         "title": "Trigger a new event"
       },
@@ -220,6 +227,11 @@
         {
           "command": "stripe.clearRecentLogs",
           "when": "view == stripeLogsView",
+          "group": "navigation"
+        },
+        {
+          "command": "stripe.clearRecentEvents",
+          "when": "view == stripeEventsView",
           "group": "navigation"
         }
       ],

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -132,6 +132,11 @@ export class Commands {
     stripeEventsViewProvider.stopStreaming();
   };
 
+  clearRecentEvents = (stripeEventsViewProvider: StripeEventsViewProvider) => {
+    this.telemetry.sendEvent('clearRecentEvents');
+    stripeEventsViewProvider.clearItems();
+  };
+
   startLogsStreaming = (stripeLogsViewProvider: StripeLogsViewProvider) => {
     this.telemetry.sendEvent('startLogsStreaming');
     stripeLogsViewProvider.startStreaming();

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -219,17 +219,10 @@ export class Commands {
     const {id, type} = data;
     const filename = `${type} (${id})`;
     const uri = vscode.Uri.parse(`stripeEvent:${filename}`);
-    vscode.window.withProgress(
-      {
-        location: vscode.ProgressLocation.Window,
-        title: 'Fetching Stripe event details',
-      },
-      async () => {
-        const doc = await vscode.workspace.openTextDocument(uri);
-        vscode.languages.setTextDocumentLanguage(doc, 'json');
-        vscode.window.showTextDocument(doc, {preview: false});
-      },
-    );
+    vscode.workspace
+      .openTextDocument(uri)
+      .then((doc) => vscode.languages.setTextDocumentLanguage(doc, 'json'))
+      .then((doc) => vscode.window.showTextDocument(doc, {preview: false}));
   };
 
   openTriggerEvent = async (extensionContext: vscode.ExtensionContext) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,9 +15,12 @@ import {StripeLogsViewProvider} from './stripeLogsView';
 import {StripeTerminal} from './stripeTerminal';
 import {SurveyPrompt} from './surveyPrompt';
 import {TelemetryPrompt} from './telemetryPrompt';
+import {initializeStripeWorkspaceState} from './stripeWorkspaceState';
 import path from 'path';
 
 export function activate(this: any, context: ExtensionContext) {
+  initializeStripeWorkspaceState(context);
+
   new TelemetryPrompt(context).activate();
   new SurveyPrompt(context).activate();
 
@@ -26,7 +29,7 @@ export function activate(this: any, context: ExtensionContext) {
 
   const stripeClient = new StripeClient(telemetry);
 
-  const stripeEventsViewProvider = new StripeEventsViewProvider(stripeClient);
+  const stripeEventsViewProvider = new StripeEventsViewProvider(stripeClient, context);
   window.createTreeView('stripeEventsView', {
     treeDataProvider: stripeEventsViewProvider,
     showCollapseAll: true,
@@ -53,7 +56,7 @@ export function activate(this: any, context: ExtensionContext) {
 
   workspace.registerTextDocumentContentProvider(
     'stripeEvent',
-    new StripeEventTextDocumentContentProvider(stripeClient),
+    new StripeEventTextDocumentContentProvider(context),
   );
 
   const git = new Git();
@@ -112,6 +115,7 @@ export function activate(this: any, context: ExtensionContext) {
       'stripe.stopEventsStreaming',
       () => stripeCommands.stopEventsStreaming(stripeEventsViewProvider),
     ],
+    ['stripe.clearRecentEvents', () => stripeCommands.clearRecentEvents(stripeEventsViewProvider)],
     ['stripe.startLogsStreaming', () => stripeCommands.startLogsStreaming(stripeLogsViewProvider)],
     ['stripe.stopLogsStreaming', () => stripeCommands.stopLogsStreaming(stripeLogsViewProvider)],
     ['stripe.clearRecentLogs', () => stripeCommands.clearRecentLogs(stripeLogsViewProvider)],

--- a/src/stripeEventTextDocumentContentProvider.ts
+++ b/src/stripeEventTextDocumentContentProvider.ts
@@ -1,22 +1,22 @@
 import * as vscode from 'vscode';
-import {StripeClient} from './stripeClient';
+import {retrieveEventDetails} from './stripeWorkspaceState';
 
 export class StripeEventTextDocumentContentProvider implements vscode.TextDocumentContentProvider {
   private static EVENT_ID_REGEXP = /evt_[\w]+/;
 
-  private stripeClient: StripeClient;
+  private extensionContext: vscode.ExtensionContext;
 
-  constructor(stripeClient: StripeClient) {
-    this.stripeClient = stripeClient;
+  constructor(extensionContext: vscode.ExtensionContext) {
+    this.extensionContext = extensionContext;
   }
 
-  async provideTextDocumentContent(uri: vscode.Uri): Promise<string | null> {
+  provideTextDocumentContent(uri: vscode.Uri): string | null {
     const eventId = this.getResourceIdFromUri(uri);
     if (!eventId) {
       return null;
     }
 
-    const eventResource = await this.stripeClient.getResourceById(eventId);
+    const eventResource = retrieveEventDetails(this.extensionContext, eventId);
 
     // respect workspace tab settings, or default to 2 spaces
     const editorConfig = vscode.workspace.getConfiguration('editor');

--- a/src/stripeStreamingView.ts
+++ b/src/stripeStreamingView.ts
@@ -53,10 +53,10 @@ export abstract class StreamingViewDataProvider extends StripeTreeViewDataProvid
     this.setViewState(ViewState.Idle);
   };
 
-  clearItems = () => {
+  clearItems() {
     this.streamingTreeItems = [];
     this.refresh();
-  };
+  }
 
   protected getStreamingControlItem(
     viewName: string,

--- a/src/stripeWorkspaceState.ts
+++ b/src/stripeWorkspaceState.ts
@@ -3,7 +3,20 @@ import * as vscode from 'vscode';
 // Set a limit on the number of eventNames we store in context.
 const recentEventsLimit = 100;
 
+// Used to keep track of the most recently triggered event names to display on top for users when they trigger events
 export const recentEventsKey = 'RecentEvents';
+
+// Used to keep track of event details for event tree items while event streaming is active.
+export const eventDetailsKey = 'EventDetails';
+
+/**
+ * Initialize the keys that we depend on
+ * If the keys are already there and have data for whatever reason, clear it.
+ */
+export function initializeStripeWorkspaceState(extensionContext: vscode.ExtensionContext) {
+  clearRecordedEvents(extensionContext);
+  clearEventDetails(extensionContext);
+}
 
 export function getRecentEvents(
   extensionContext: vscode.ExtensionContext,
@@ -21,4 +34,27 @@ export function recordEvent(extensionContext: vscode.ExtensionContext, eventName
 
 export function clearRecordedEvents(extensionContext: vscode.ExtensionContext) {
   extensionContext.workspaceState.update(recentEventsKey, []);
+}
+
+function getEventDetailsMap(extensionContext: vscode.ExtensionContext) {
+  return extensionContext.workspaceState.get(eventDetailsKey, new Map<string, any>());
+}
+
+export function addEventDetails(
+  extensionContext: vscode.ExtensionContext,
+  eventId: string,
+  eventObject: any,
+) {
+  const eventDetailsMap = getEventDetailsMap(extensionContext);
+  eventDetailsMap.set(eventId, eventObject);
+  extensionContext.workspaceState.update(eventDetailsKey, eventDetailsMap);
+}
+
+export function retrieveEventDetails(extensionContext: vscode.ExtensionContext, eventId: string) {
+  const eventDetailsMap = getEventDetailsMap(extensionContext);
+  return eventDetailsMap.get(eventId);
+}
+
+export function clearEventDetails(extensionContext: vscode.ExtensionContext) {
+  extensionContext.workspaceState.update(eventDetailsKey, new Map<string, any>());
 }


### PR DESCRIPTION
…t document source

* The event details document was retrieved from the CLI with the eventId. Since we added event streaming we now have access to the entire blob. This change updates the event streaming to store this data in workspace context and updates the text document provider to fetch from there as well.
* Added a clear recent events functionality. This also clears the event data from the workspace context.

## Note for the reviewer
You may be wondering why I didn't just keep the event data in the TreeItem itself. Originally, that's what I did and bypassed the `stripeEventDocumentationProvider` entirely by just creating a document within the `openEventDetails` command. However, if you create a document with the content, it gets saved to the "Untitled" schema, which not only is an unhelpful name, but is also editable. 

A custom textDocumentProvider allows us to create readonly documents to the editor, but the interface doesn't allow us to pass in the content when we invoke the provider, only the URI. So I opted for keeping the text document provider, but replacing the stripeClient with extensionContext as the provider source. 

## Testing
There is no visible difference for the open event details UI, but I manually tested it to make sure that it's still working as it did before.

Also manually tested the clear events functionality, and added some unit tests for the management of the new storage key. 
