### PR TITLE
Save user input to Start webhooks listening

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -92,9 +92,9 @@ export class Commands {
         ['Yes', 'No'],
       )) === 'Yes';
 
-    const forwardTo = await (async () => {
+    const [forwardTo, forwardConnectTo] = await (async () => {
       if (!shouldPromptForURL) {
-        return options.forwardTo;
+        return [options.forwardTo, options.forwardConnectTo];
       }
 
       const defaultForwardToURL = 'http://localhost:3000';
@@ -103,30 +103,21 @@ export class Commands {
         prompt: 'Enter local server URL to forward webhook events to',
         value: getWebhookEndpoint(this.context) || defaultForwardToURL,
       });
-
-      if (forwardToInput) {
-        setWebhookEndpoint(this.context, forwardToInput); // save value for next invocation
-      }
-
-      return forwardToInput;
-    })();
-
-    const forwardConnectTo = await (async () => {
-      if (!shouldPromptForURL) {
-        return options.forwardConnectTo;
-      }
-
       const forwardConnectToInput = await vscode.window.showInputBox({
         prompt:
           'Enter local server URL to forward Connect webhook events to (default: same as normal events)',
-        value: getConnectWebhookEndpoint(this.context) || forwardTo,
+        value: getConnectWebhookEndpoint(this.context) || forwardToInput,
       });
 
+      // save values for next invocation
+      if (forwardToInput) {
+        setWebhookEndpoint(this.context, forwardToInput);
+      }
       if (forwardConnectToInput) {
-        setConnectWebhookEndpoint(this.context, forwardConnectToInput); // save value for next invocation
+        setConnectWebhookEndpoint(this.context, forwardConnectToInput);
       }
 
-      return forwardConnectToInput;
+      return [forwardToInput, forwardConnectToInput];
     })();
 
     const invalidURLCharsRE = /[^\w-.~:\/?#\[\]@!$&'()*+,;=]/;

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -85,8 +85,8 @@ export class Commands {
     this.telemetry.sendEvent('openWebhooksListen');
 
     const shouldPromptForURL =
-      !options.forwardTo &&
-      !options.forwardConnectTo &&
+      !options?.forwardTo &&
+      !options?.forwardConnectTo &&
       (await showQuickPickWithValues(
         'Do you want to forward webhook events to your local server?',
         ['Yes', 'No'],
@@ -94,7 +94,7 @@ export class Commands {
 
     const [forwardTo, forwardConnectTo] = await (async () => {
       if (!shouldPromptForURL) {
-        return [options.forwardTo, options.forwardConnectTo];
+        return [options?.forwardTo, options?.forwardConnectTo];
       }
 
       const defaultForwardToURL = 'http://localhost:3000';
@@ -127,7 +127,7 @@ export class Commands {
       return;
     }
 
-    if (Array.isArray(options.events)) {
+    if (Array.isArray(options?.events)) {
       const invalidEventCharsRE = /[^a-z_.]/;
       const invalidEvent = options.events.find((e: string) => invalidEventCharsRE.test(e));
       if (invalidEvent) {
@@ -142,7 +142,7 @@ export class Commands {
     const forwardConnectToFlag = forwardConnectTo ? ['--forward-connect-to', forwardConnectTo] : [];
 
     const eventsFlag =
-      Array.isArray(options.events) && options.events.length > 0
+      Array.isArray(options?.events) && options.events.length > 0
         ? ['--events', options.events.join(',')]
         : [];
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -83,7 +83,7 @@ export function activate(this: any, context: ExtensionContext) {
 
   const stripeTerminal = new StripeTerminal(stripeClient);
 
-  const stripeCommands = new Commands(telemetry, stripeTerminal);
+  const stripeCommands = new Commands(telemetry, stripeTerminal, context);
 
   const commandCallbackPairs: [string, (...args: any[]) => any][] = [
     ['stripe.login', stripeCommands.startLogin],

--- a/src/stripeWorkspaceState.ts
+++ b/src/stripeWorkspaceState.ts
@@ -65,8 +65,8 @@ export function clearEventDetails(extensionContext: vscode.ExtensionContext) {
   extensionContext.workspaceState.update(eventDetailsKey, new Map<string, any>());
 }
 
-export function getWebhookEndpoint(extensionContext: vscode.ExtensionContext) {
-  return extensionContext.workspaceState.get(webhookEndpointKey, null);
+export function getWebhookEndpoint(extensionContext: vscode.ExtensionContext): string | undefined {
+  return extensionContext.workspaceState.get(webhookEndpointKey);
 }
 
 export function setWebhookEndpoint(
@@ -76,8 +76,10 @@ export function setWebhookEndpoint(
   extensionContext.workspaceState.update(webhookEndpointKey, webhookEndpoint);
 }
 
-export function getConnectWebhookEndpoint(extensionContext: vscode.ExtensionContext) {
-  return extensionContext.workspaceState.get(connectWebhookEndpointKey, null);
+export function getConnectWebhookEndpoint(
+  extensionContext: vscode.ExtensionContext,
+): string | undefined {
+  return extensionContext.workspaceState.get(connectWebhookEndpointKey);
 }
 
 export function setConnectWebhookEndpoint(

--- a/src/stripeWorkspaceState.ts
+++ b/src/stripeWorkspaceState.ts
@@ -9,6 +9,12 @@ export const recentEventsKey = 'RecentEvents';
 // Used to keep track of event details for event tree items while event streaming is active.
 export const eventDetailsKey = 'EventDetails';
 
+// Used to keep track of the last endpoint the user set to forward webhook events to.
+export const webhookEndpointKey = 'WebhookEndpoint';
+
+// Used to keep track of the last endpoint the user set to forward Connect webhook events to.
+export const connectWebhookEndpointKey = 'ConnectWebhookEndpoint';
+
 /**
  * Initialize the keys that we depend on
  * If the keys are already there and have data for whatever reason, clear it.
@@ -57,4 +63,26 @@ export function retrieveEventDetails(extensionContext: vscode.ExtensionContext, 
 
 export function clearEventDetails(extensionContext: vscode.ExtensionContext) {
   extensionContext.workspaceState.update(eventDetailsKey, new Map<string, any>());
+}
+
+export function getWebhookEndpoint(extensionContext: vscode.ExtensionContext) {
+  return extensionContext.workspaceState.get(webhookEndpointKey, null);
+}
+
+export function setWebhookEndpoint(
+  extensionContext: vscode.ExtensionContext,
+  webhookEndpoint: string,
+) {
+  extensionContext.workspaceState.update(webhookEndpointKey, webhookEndpoint);
+}
+
+export function getConnectWebhookEndpoint(extensionContext: vscode.ExtensionContext) {
+  return extensionContext.workspaceState.get(connectWebhookEndpointKey, null);
+}
+
+export function setConnectWebhookEndpoint(
+  extensionContext: vscode.ExtensionContext,
+  connectWebhookEndpoint: string,
+) {
+  extensionContext.workspaceState.update(connectWebhookEndpointKey, connectWebhookEndpoint);
 }

--- a/test/suite/commands.test.ts
+++ b/test/suite/commands.test.ts
@@ -31,7 +31,7 @@ suite('commands', () => {
 
       const supportedEvents = ['a'];
 
-      const commands = new Commands(telemetry, terminal, supportedEvents);
+      const commands = new Commands(telemetry, terminal, extensionContext, supportedEvents);
       commands.openTriggerEvent(extensionContext);
       // Pick the first item on the list.
       await vscode.commands.executeCommand('workbench.action.acceptSelectedQuickOpenItem');
@@ -47,7 +47,7 @@ suite('commands', () => {
     test('returns all original events when no recent events', () => {
       const extensionContext = {...mocks.extensionContextMock};
       const getEventsStub = sandbox.stub(stripeState, 'getRecentEvents').returns([]);
-      const commands = new Commands(telemetry, terminal);
+      const commands = new Commands(telemetry, terminal, extensionContext);
       const supportedEvents = ['a', 'b', 'c', 'd', 'e'];
       const events = commands.buildTriggerEventsList(supportedEvents, extensionContext);
 
@@ -59,7 +59,7 @@ suite('commands', () => {
     test('returns recent events on top', () => {
       const extensionContext = {...mocks.extensionContextMock};
       const getEventsStub = sandbox.stub(stripeState, 'getRecentEvents').returns(['c']);
-      const commands = new Commands(telemetry, terminal);
+      const commands = new Commands(telemetry, terminal, extensionContext);
 
       const supportedEvents = ['a', 'b', 'c', 'd', 'e'];
       const events = commands.buildTriggerEventsList(supportedEvents, extensionContext);
@@ -75,7 +75,7 @@ suite('commands', () => {
       const getEventsStub = sandbox
         .stub(stripeState, 'getRecentEvents')
         .returns(['c', 'unsupported']);
-      const commands = new Commands(telemetry, terminal);
+      const commands = new Commands(telemetry, terminal, extensionContext);
 
       const supportedEvents = ['a', 'b', 'c', 'd', 'e'];
       const events = commands.buildTriggerEventsList(supportedEvents, extensionContext);

--- a/test/suite/stripeWorkspaceState.test.ts
+++ b/test/suite/stripeWorkspaceState.test.ts
@@ -5,12 +5,18 @@ import {TestMemento, mocks} from '../mocks/vscode';
 import {
   addEventDetails,
   clearEventDetails,
+  connectWebhookEndpointKey,
   eventDetailsKey,
+  getConnectWebhookEndpoint,
   getRecentEvents,
+  getWebhookEndpoint,
   initializeStripeWorkspaceState,
   recentEventsKey,
   recordEvent,
   retrieveEventDetails,
+  setConnectWebhookEndpoint,
+  setWebhookEndpoint,
+  webhookEndpointKey,
 } from '../../src/stripeWorkspaceState';
 
 suite('stripeWorkspaceState', () => {
@@ -34,6 +40,15 @@ suite('stripeWorkspaceState', () => {
 
     // Verify EventDetails is present with an empy Map
     assert.deepStrictEqual(extensionContext.workspaceState.get(eventDetailsKey), new Map());
+
+    // Verify WebhookEndpointKey is not set
+    assert.deepStrictEqual(extensionContext.workspaceState.get(webhookEndpointKey), undefined);
+
+    // Verify ConnectWebhookEndpointKey is not set
+    assert.deepStrictEqual(
+      extensionContext.workspaceState.get(connectWebhookEndpointKey),
+      undefined,
+    );
   });
 
   suite('RecentEvents', () => {
@@ -100,6 +115,32 @@ suite('stripeWorkspaceState', () => {
       clearEventDetails(extensionContext);
 
       assert.deepStrictEqual(extensionContext.workspaceState.get(eventDetailsKey), new Map());
+    });
+  });
+
+  suite('WebhookEndpoint', () => {
+    test('set and get webhook endpoint', () => {
+      const workspaceState = new TestMemento();
+      const extensionContext = {...mocks.extensionContextMock, workspaceState: workspaceState};
+
+      const webhookEndpoint = 'http://localhost:4242/my-webhook-endpoint';
+
+      setWebhookEndpoint(extensionContext, webhookEndpoint);
+
+      assert.deepStrictEqual(getWebhookEndpoint(extensionContext), webhookEndpoint);
+    });
+  });
+
+  suite('ConnectWebhookEndpoint', () => {
+    test('set and get Connect webhook endpoint', () => {
+      const workspaceState = new TestMemento();
+      const extensionContext = {...mocks.extensionContextMock, workspaceState: workspaceState};
+
+      const connectWebhookEndpoint = 'http://localhost:4242/my-connect-webhook-endpoint';
+
+      setConnectWebhookEndpoint(extensionContext, connectWebhookEndpoint);
+
+      assert.deepStrictEqual(getConnectWebhookEndpoint(extensionContext), connectWebhookEndpoint);
     });
   });
 });

--- a/test/suite/stripeWorkspaceState.test.ts
+++ b/test/suite/stripeWorkspaceState.test.ts
@@ -42,13 +42,10 @@ suite('stripeWorkspaceState', () => {
     assert.deepStrictEqual(extensionContext.workspaceState.get(eventDetailsKey), new Map());
 
     // Verify WebhookEndpointKey is not set
-    assert.deepStrictEqual(extensionContext.workspaceState.get(webhookEndpointKey), undefined);
+    assert.strictEqual(extensionContext.workspaceState.get(webhookEndpointKey), undefined);
 
     // Verify ConnectWebhookEndpointKey is not set
-    assert.deepStrictEqual(
-      extensionContext.workspaceState.get(connectWebhookEndpointKey),
-      undefined,
-    );
+    assert.strictEqual(extensionContext.workspaceState.get(connectWebhookEndpointKey), undefined);
   });
 
   suite('RecentEvents', () => {


### PR DESCRIPTION
fixes #168 

Before: We always pre-fill the "Start webhooks listening" input box with localhost:3000.
After: We pre-fill the input box with the user's most recent input. This is per-workspace as suggested in the issue.

Tested manually:
- clicking "Start webhooks listening"
- invoking the command through the debugger
- invoking the command through the command palette
  - this actually didn't work before this PR