### PR TITLE
Updating the extension activation triggers to only include Stripe-rel…

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,6 @@
     "finance"
   ],
   "activationEvents": [
-    "onDebugInitialConfigurations",
-    "onDebug",
     "onView:stripeEventsView",
     "onView:stripeLogsView",
     "onView:stripeDashboardView",
@@ -56,15 +54,7 @@
     "onCommand:stripe.clearRecentLogs",
     "onCommand:stripe.clearRecentEvents",
     "onCommand:stripe.startEventsStreaming",
-    "onCommand:stripe.stopEventsStreaming",
-    "onLanguage:typescript",
-    "onLanguage:javascript",
-    "onLanguage:csharp",
-    "onLanguage:go",
-    "onLanguage:python",
-    "onLanguage:ruby",
-    "onLanguage:java",
-    "onLanguage:php"
+    "onCommand:stripe.stopEventsStreaming"
   ],
   "main": "./dist/extension.js",
   "contributes": {


### PR DESCRIPTION
…ated actions.

cc @richardg-stripe 
r? @vcheung-stripe 

# Summary
This change is in response to https://github.com/stripe/vscode-stripe/issues/187 and will only trigger the activation of the extension if the users opens up the extension panel or tries to run a stripe command.

This does prevent the pre-loading of the extension which could mean that users experience a slower response for their first Stripe command (but I haven't noticed this while testing). If we find that our activation is heavy enough to benefit from loading earlier, another alternative is to move all the prompt-producing checks out of the activation step. I think that would complicate things though so I'd rather give this a try first. 

# Testing
Moved my stripe installation to another folder the extension wouldn't be able to find.

1. Verified that the installation pop-up does not show up when the workspace is first opened.
2. Verified that the installation pop-up does show up when clicking the Stripe extension
3. Verified that the pop-up shows up when directly picking a command from the command palette. 