### PR TITLE
Use a welcome view instead of modal to prompt CLI installation

### DIFF
--- a/package.json
+++ b/package.json
@@ -211,12 +211,19 @@
     "views": {
       "stripe": [
         {
+          "id": "stripeInstallCLIView",
+          "name": "Install Stripe CLI",
+          "when": "stripe.isCLIInstalled == false"
+        },
+        {
           "id": "stripeEventsView",
-          "name": "Events"
+          "name": "Events",
+          "when": "stripe.isCLIInstalled == true"
         },
         {
           "id": "stripeLogsView",
-          "name": "Logs"
+          "name": "Logs",
+          "when": "stripe.isCLIInstalled == true"
         },
         {
           "id": "stripeDashboardView",
@@ -228,6 +235,12 @@
         }
       ]
     },
+    "viewsWelcome": [
+      {
+        "view": "stripeInstallCLIView",
+        "contents": "Welcome! The Stripe VS Code extension requires the Stripe CLI.\n[Install Stripe CLI](https://stripe.com/docs/stripe-cli#install)\n[Set a custom path to Stripe CLI](command:workbench.action.openSettings?%5B%22stripe.cliInstallPath%22%5D)\nLearn more about [how to use the Stripe extension for Visual Studio Code](https://stripe.com/docs/stripe-vscode)."
+      }
+    ],
     "menus": {
       "view/title": [
         {

--- a/package.json
+++ b/package.json
@@ -213,17 +213,17 @@
         {
           "id": "stripeInstallCLIView",
           "name": "Install Stripe CLI",
-          "when": "stripe.isCLIInstalled == false"
+          "when": "stripe.isNotCLIInstalled == true"
         },
         {
           "id": "stripeEventsView",
           "name": "Events",
-          "when": "stripe.isCLIInstalled == true"
+          "when": "stripe.isNotCLIInstalled == false"
         },
         {
           "id": "stripeLogsView",
           "name": "Logs",
-          "when": "stripe.isCLIInstalled == true"
+          "when": "stripe.isNotCLIInstalled == false"
         },
         {
           "id": "stripeDashboardView",

--- a/src/stripeClient.ts
+++ b/src/stripeClient.ts
@@ -102,7 +102,7 @@ export class StripeClient {
     }
   }
 
-  private async promptLogin() {
+  async promptLogin() {
     const actionText = 'Run `stripe login` in the terminal to login';
     const returnValue = await vscode.window.showErrorMessage(
       'You need to login with the Stripe CLI for this project before you can continue',
@@ -125,12 +125,6 @@ export class StripeClient {
     const cliPath = await this.cliPath;
     if (cliPath) {
       this.checkCLIVersion();
-
-      // isAuthenticated
-      const isAuthenticated = await this.isAuthenticated();
-      if (!isAuthenticated) {
-        await this.promptLogin();
-      }
     } else {
       const config = vscode.workspace.getConfiguration('stripe');
       const customInstallPath = config.get('cliInstallPath', null);
@@ -182,6 +176,11 @@ export class StripeClient {
     const cliPath = await this.getCLIPath();
     if (!cliPath) {
       return null;
+    }
+
+    const isAuthenticated = await this.isAuthenticated();
+    if (!isAuthenticated) {
+      await this.promptLogin();
     }
 
     const commandArgs = cliCommandToArgsMap.get(cliCommand);
@@ -244,6 +243,10 @@ export class StripeClient {
     if (shouldHandleConfigurationChange) {
       // kick off cliPath check
       await this.getCLIPath();
+      const isAuthenticated = await this.isAuthenticated();
+      if (!isAuthenticated) {
+        await this.promptLogin();
+      }
     }
   }
 }

--- a/src/stripeTerminal.ts
+++ b/src/stripeTerminal.ts
@@ -22,6 +22,13 @@ export class StripeTerminal {
       return;
     }
 
+    if (command !== 'login') {
+      const isAuthenticated = await this.stripeClient.isAuthenticated();
+      if (!isAuthenticated) {
+        await this.stripeClient.promptLogin();
+      }
+    }
+
     const globalCLIFLags = this.getGlobalCLIFlags();
 
     const commandString = [cliPath, command, ...args, ...globalCLIFLags].join(' ');

--- a/test/suite/stripeClient.test.ts
+++ b/test/suite/stripeClient.test.ts
@@ -99,16 +99,13 @@ suite('stripeClient', () => {
 
       test('prompts install when CLI is not installed', async () => {
         sandbox.stub(fs.promises, 'stat').returns(Promise.resolve({isFile: () => false}));
-        const showErrorMessageSpy = sandbox.stub(vscode.window, 'showErrorMessage');
+        const executeCommandSpy = sandbox.stub(vscode.commands, 'executeCommand');
         const stripeClient = getStripeClient();
         sandbox.stub(stripeClient, 'checkCLIVersion');
         sandbox.stub(stripeClient, 'isAuthenticated').resolves(true);
         const cliPath = await stripeClient.getCLIPath();
         assert.strictEqual(cliPath, null);
-        assert.deepStrictEqual(showErrorMessageSpy.args[0], [
-          'Welcome! Stripe is using the Stripe CLI behind the scenes, and requires it to be installed on your machine',
-          'Read instructions on how to install Stripe CLI',
-        ]);
+        assert.deepStrictEqual(executeCommandSpy.calledWith('stripeInstallCLIView.focus'), true);
       });
     });
 

--- a/test/suite/stripeClient.test.ts
+++ b/test/suite/stripeClient.test.ts
@@ -107,7 +107,6 @@ suite('stripeClient', () => {
         assert.strictEqual(cliPath, null);
         assert.deepStrictEqual(showErrorMessageSpy.args[0], [
           'Welcome! Stripe is using the Stripe CLI behind the scenes, and requires it to be installed on your machine',
-          {modal: true},
           'Read instructions on how to install Stripe CLI',
         ]);
       });

--- a/test/suite/stripeTerminal.test.ts
+++ b/test/suite/stripeTerminal.test.ts
@@ -34,7 +34,7 @@ suite('stripeTerminal', function () {
         const createTerminalStub = sandbox
           .stub(vscode.window, 'createTerminal')
           .returns(terminalStub);
-        const stripeClientStub = <any>{getCLIPath: () => {}};
+        const stripeClientStub = <any>{getCLIPath: () => {}, isAuthenticated: () => true};
         const getCLIPathStub = sandbox
           .stub(stripeClientStub, 'getCLIPath')
           .returns(Promise.resolve(path));
@@ -55,7 +55,7 @@ suite('stripeTerminal', function () {
       const createTerminalStub = sandbox
         .stub(vscode.window, 'createTerminal')
         .returns(terminalStub);
-      const stripeClientStub = <any>{getCLIPath: () => {}};
+      const stripeClientStub = <any>{getCLIPath: () => {}, isAuthenticated: () => true};
       sandbox.stub(stripeClientStub, 'getCLIPath').returns(null);
 
       const stripeTerminal = new StripeTerminal(stripeClientStub);


### PR DESCRIPTION
fixes #57 

When the CLI can't be detected, show a welcome view on startup:
![Screen Shot 2021-05-11 at 12 13 15 PM](https://user-images.githubusercontent.com/71457708/117872976-23a5d680-b254-11eb-8772-6078edaf8bb5.png)

After CLI is installed, refresh to see the logs and events views:

https://user-images.githubusercontent.com/71457708/117872968-21dc1300-b254-11eb-840e-ddb01a0af05b.mov

Authentication is not a part of this flow. We may want to improve this later:

https://user-images.githubusercontent.com/71457708/117872967-21437c80-b254-11eb-93d1-70b3938abcdb.mov

If the CLI is uninstalled while the extension is active, commands will fail and the welcome view will be focused:

https://user-images.githubusercontent.com/71457708/117872961-20aae600-b254-11eb-8909-51cdb269614d.mov

Same scenario, but the stripe extension is not in view. The welcome view will be focused:

https://user-images.githubusercontent.com/71457708/117872955-1e488c00-b254-11eb-9bf9-3cd8691d9b58.mov






