### PR TITLE
Fix tests that use workspace

### DIFF
--- a/test/suite/commands.test.ts
+++ b/test/suite/commands.test.ts
@@ -11,7 +11,9 @@ import {SurveyPrompt} from '../../src/surveyPrompt';
 import childProcess from 'child_process';
 import {mocks} from '../mocks/vscode';
 
-suite('commands', () => {
+suite('commands', function () {
+  this.timeout(20000);
+
   let sandbox: sinon.SinonSandbox;
   let extensionContext: vscode.ExtensionContext;
 

--- a/test/suite/stripeLinter.test.ts
+++ b/test/suite/stripeLinter.test.ts
@@ -21,9 +21,8 @@ suite('StripeLinter', () => {
   suite('lookForHardCodedAPIKeys', () => {
     test('Editor content is not searched when file is git-ignored', async () => {
       const options = {content: 'I have content with critical data : sk_live_1234'};
-      await vscode.workspace
-        .openTextDocument(options)
-        .then((doc) => vscode.window.showTextDocument(doc, {preview: false}));
+      const doc = await vscode.workspace.openTextDocument(options);
+      await vscode.window.showTextDocument(doc, {preview: false});
 
       const isIgnoredStub = sandbox.stub(git, 'isIgnored').resolves(true);
       const telemetrySpy = sandbox.spy(telemetry, 'sendEvent');
@@ -31,7 +30,7 @@ suite('StripeLinter', () => {
       const linter = new StripeLinter(telemetry, git);
       await linter.activate();
 
-      const diagnostics = vscode.languages.getDiagnostics();
+      const diagnostics = vscode.languages.getDiagnostics(doc.uri);
       assert.strictEqual(isIgnoredStub.calledOnce, true);
       assert.strictEqual(telemetrySpy.callCount, 0);
       assert.strictEqual(diagnostics.length, 0);


### PR DESCRIPTION
- Some telemetry tests were failing because of timeout. They make several vscode API calls, which not only slows down the tests, but also makes the test output very noisy. This PR replaces those calls with stubs.
- Those vscode API calls relied on a dummy workspace. Since we don't make those calls anymore, I removed the dummy workspace folder.
- I also updated a linter test that was failing after removing the dummy workspace folder.