### PR TITLE
Removing Google Analytics Telemetry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "version": "1.7.5",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@types/universal-analytics": "^0.4.4",
         "byline": "^5.0.0",
         "compare-versions": "^3.6.0",
         "execa": "^4.0.0",
@@ -17,7 +16,6 @@
         "proxyquire": "^2.1.3",
         "remark-gfm": "^1.0.0",
         "toml": "^3.0.0",
-        "universal-analytics": "^0.4.20",
         "uuid": "^3.4.0",
         "vscode-languageclient": "^6.1.3",
         "vscode-languageserver": "^6.1.1",
@@ -331,10 +329,6 @@
     },
     "node_modules/@types/unist": {
       "version": "2.0.3",
-      "license": "MIT"
-    },
-    "node_modules/@types/universal-analytics": {
-      "version": "0.4.4",
       "license": "MIT"
     },
     "node_modules/@types/uuid": {
@@ -826,6 +820,7 @@
     },
     "node_modules/ajv": {
       "version": "6.12.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -975,20 +970,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/asn1": {
-      "version": "0.2.4",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
-    "node_modules/assert-plus": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/astral-regex": {
       "version": "1.0.0",
       "dev": true,
@@ -1006,21 +987,6 @@
         "lodash": "^4.17.14"
       }
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "license": "MIT"
-    },
-    "node_modules/aws-sign2": {
-      "version": "0.7.0",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/aws4": {
-      "version": "1.9.1",
-      "license": "MIT"
-    },
     "node_modules/bail": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
@@ -1035,13 +1001,6 @@
       "version": "1.0.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "tweetnacl": "^0.14.3"
-      }
     },
     "node_modules/big.js": {
       "version": "5.2.2",
@@ -1375,10 +1334,6 @@
       "dev": true,
       "license": "CC-BY-4.0"
     },
-    "node_modules/caseless": {
-      "version": "0.12.0",
-      "license": "Apache-2.0"
-    },
     "node_modules/ccount": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.1.0.tgz",
@@ -1591,16 +1546,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/commander": {
       "version": "2.20.3",
       "dev": true,
@@ -1634,6 +1579,7 @@
     },
     "node_modules/core-util-is": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
@@ -1657,18 +1603,9 @@
         "node": ">=8"
       }
     },
-    "node_modules/dashdash": {
-      "version": "1.14.1",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/debug": {
       "version": "3.2.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
@@ -1723,13 +1660,6 @@
       "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==",
       "dev": true
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/dir-glob": {
       "version": "3.0.1",
       "dev": true,
@@ -1769,14 +1699,6 @@
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
       "dev": true
-    },
-    "node_modules/ecc-jsbn": {
-      "version": "0.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
-      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.3.703",
@@ -2237,6 +2159,7 @@
     },
     "node_modules/extend": {
       "version": "3.0.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/external-editor": {
@@ -2253,15 +2176,9 @@
         "node": ">=4"
       }
     },
-    "node_modules/extsprintf": {
-      "version": "1.3.0",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "license": "MIT"
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -2282,6 +2199,7 @@
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
@@ -2401,25 +2319,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/forever-agent": {
-      "version": "0.6.1",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "2.3.3",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 0.12"
-      }
-    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "dev": true,
@@ -2462,13 +2361,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/getpass": {
-      "version": "0.1.7",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
       }
     },
     "node_modules/glob": {
@@ -2609,24 +2501,6 @@
         "node": ">=4.x"
       }
     },
-    "node_modules/har-schema": {
-      "version": "2.0.0",
-      "license": "ISC",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/har-validator": {
-      "version": "5.1.3",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.5.5",
-        "har-schema": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/has": {
       "version": "1.0.3",
       "license": "MIT",
@@ -2698,19 +2572,6 @@
       "version": "2.0.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/http-signature": {
-      "version": "1.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
-      },
-      "engines": {
-        "node": ">=0.8",
-        "npm": ">=1.3.7"
-      }
     },
     "node_modules/https-proxy-agent": {
       "version": "2.2.4",
@@ -3143,6 +3004,7 @@
     },
     "node_modules/is-typedarray": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-yarn-global": {
@@ -3167,10 +3029,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/isstream": {
-      "version": "0.1.2",
-      "license": "MIT"
     },
     "node_modules/jest-worker": {
       "version": "26.6.2",
@@ -3221,10 +3079,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/jsbn": {
-      "version": "0.1.1",
-      "license": "MIT"
-    },
     "node_modules/json-buffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
@@ -3242,21 +3096,15 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
     },
-    "node_modules/json-schema": {
-      "version": "0.2.3"
-    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/json-stringify-safe": {
-      "version": "5.0.1",
-      "license": "ISC"
     },
     "node_modules/json5": {
       "version": "2.2.0",
@@ -3270,19 +3118,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/jsprim": {
-      "version": "1.4.1",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
-        "verror": "1.10.0"
       }
     },
     "node_modules/just-extend": {
@@ -3750,6 +3585,7 @@
     },
     "node_modules/mime-db": {
       "version": "1.46.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -3757,6 +3593,7 @@
     },
     "node_modules/mime-types": {
       "version": "2.1.29",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.46.0"
@@ -4338,13 +4175,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/oauth-sign": {
-      "version": "0.9.0",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/once": {
       "version": "1.4.0",
       "license": "ISC",
@@ -4686,10 +4516,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/performance-now": {
-      "version": "2.1.0",
-      "license": "MIT"
-    },
     "node_modules/picomatch": {
       "version": "2.2.2",
       "dev": true,
@@ -4760,10 +4586,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/psl": {
-      "version": "1.8.0",
-      "license": "MIT"
-    },
     "node_modules/pump": {
       "version": "3.0.0",
       "license": "MIT",
@@ -4774,6 +4596,7 @@
     },
     "node_modules/punycode": {
       "version": "2.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4789,13 +4612,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/qs": {
-      "version": "6.5.2",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.6"
       }
     },
     "node_modules/randombytes": {
@@ -5020,35 +4836,6 @@
         "node": ">=0.10"
       }
     },
-    "node_modules/request": {
-      "version": "2.88.2",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "dev": true,
@@ -5210,10 +4997,12 @@
     },
     "node_modules/safe-buffer": {
       "version": "5.2.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/schema-utils": {
@@ -5438,24 +5227,6 @@
       "version": "1.0.3",
       "dev": true,
       "license": "BSD-3-Clause"
-    },
-    "node_modules/sshpk": {
-      "version": "1.16.1",
-      "license": "MIT",
-      "dependencies": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/string_decoder": {
       "version": "1.1.1",
@@ -5717,17 +5488,6 @@
       "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
       "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w=="
     },
-    "node_modules/tough-cookie": {
-      "version": "2.5.0",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/trough": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
@@ -5857,20 +5617,6 @@
       "version": "1.9.3",
       "dev": true,
       "license": "Apache-2.0"
-    },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/tweetnacl": {
-      "version": "0.14.5",
-      "license": "Unlicense"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -6002,15 +5748,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/universal-analytics": {
-      "version": "0.4.20",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^3.0.0",
-        "request": "^2.88.0",
-        "uuid": "^3.0.0"
-      }
-    },
     "node_modules/update-notifier": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-4.1.3.tgz",
@@ -6107,6 +5844,7 @@
     },
     "node_modules/uri-js": {
       "version": "4.2.2",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
@@ -6158,18 +5896,6 @@
       "dev": true,
       "dependencies": {
         "builtins": "^1.0.3"
-      }
-    },
-    "node_modules/verror": {
-      "version": "1.10.0",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
       }
     },
     "node_modules/vfile": {
@@ -7092,9 +6818,6 @@
     "@types/unist": {
       "version": "2.0.3"
     },
-    "@types/universal-analytics": {
-      "version": "0.4.4"
-    },
     "@types/uuid": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz",
@@ -7402,6 +7125,7 @@
     },
     "ajv": {
       "version": "6.12.6",
+      "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -7506,15 +7230,6 @@
       "version": "2.1.0",
       "dev": true
     },
-    "asn1": {
-      "version": "0.2.4",
-      "requires": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
-    "assert-plus": {
-      "version": "1.0.0"
-    },
     "astral-regex": {
       "version": "1.0.0",
       "dev": true
@@ -7528,15 +7243,6 @@
         "lodash": "^4.17.14"
       }
     },
-    "asynckit": {
-      "version": "0.4.0"
-    },
-    "aws-sign2": {
-      "version": "0.7.0"
-    },
-    "aws4": {
-      "version": "1.9.1"
-    },
     "bail": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
@@ -7546,12 +7252,6 @@
     "balanced-match": {
       "version": "1.0.0",
       "dev": true
-    },
-    "bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "requires": {
-        "tweetnacl": "^0.14.3"
-      }
     },
     "big.js": {
       "version": "5.2.2",
@@ -7788,9 +7488,6 @@
       "version": "1.0.30001205",
       "dev": true
     },
-    "caseless": {
-      "version": "0.12.0"
-    },
     "ccount": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.1.0.tgz",
@@ -7942,12 +7639,6 @@
       "version": "1.2.2",
       "dev": true
     },
-    "combined-stream": {
-      "version": "1.0.8",
-      "requires": {
-        "delayed-stream": "~1.0.0"
-      }
-    },
     "commander": {
       "version": "2.20.3",
       "dev": true
@@ -7974,7 +7665,8 @@
       }
     },
     "core-util-is": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "dev": true
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -7990,14 +7682,9 @@
       "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
       "dev": true
     },
-    "dashdash": {
-      "version": "1.14.1",
-      "requires": {
-        "assert-plus": "^1.0.0"
-      }
-    },
     "debug": {
       "version": "3.2.6",
+      "dev": true,
       "requires": {
         "ms": "^2.1.1"
       }
@@ -8040,9 +7727,6 @@
       "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==",
       "dev": true
     },
-    "delayed-stream": {
-      "version": "1.0.0"
-    },
     "dir-glob": {
       "version": "3.0.1",
       "dev": true,
@@ -8071,13 +7755,6 @@
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
       "dev": true
-    },
-    "ecc-jsbn": {
-      "version": "0.1.2",
-      "requires": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
-      }
     },
     "electron-to-chromium": {
       "version": "1.3.703",
@@ -8370,7 +8047,8 @@
       }
     },
     "extend": {
-      "version": "3.0.2"
+      "version": "3.0.2",
+      "dev": true
     },
     "external-editor": {
       "version": "3.1.0",
@@ -8383,11 +8061,9 @@
         "tmp": "^0.0.33"
       }
     },
-    "extsprintf": {
-      "version": "1.3.0"
-    },
     "fast-deep-equal": {
-      "version": "3.1.1"
+      "version": "3.1.1",
+      "dev": true
     },
     "fast-glob": {
       "version": "3.2.4",
@@ -8402,7 +8078,8 @@
       }
     },
     "fast-json-stable-stringify": {
-      "version": "2.1.0"
+      "version": "2.1.0",
+      "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -8482,17 +8159,6 @@
       "version": "3.1.0",
       "dev": true
     },
-    "forever-agent": {
-      "version": "0.6.1"
-    },
-    "form-data": {
-      "version": "2.3.3",
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      }
-    },
     "fs.realpath": {
       "version": "1.0.0",
       "dev": true
@@ -8517,12 +8183,6 @@
       "version": "5.1.0",
       "requires": {
         "pump": "^3.0.0"
-      }
-    },
-    "getpass": {
-      "version": "0.1.7",
-      "requires": {
-        "assert-plus": "^1.0.0"
       }
     },
     "glob": {
@@ -8620,16 +8280,6 @@
       "version": "1.10.5",
       "dev": true
     },
-    "har-schema": {
-      "version": "2.0.0"
-    },
-    "har-validator": {
-      "version": "5.1.3",
-      "requires": {
-        "ajv": "^6.5.5",
-        "har-schema": "^2.0.0"
-      }
-    },
     "has": {
       "version": "1.0.3",
       "requires": {
@@ -8681,14 +8331,6 @@
           "version": "2.0.0",
           "dev": true
         }
-      }
-    },
-    "http-signature": {
-      "version": "1.2.0",
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
       }
     },
     "https-proxy-agent": {
@@ -8968,7 +8610,8 @@
       "version": "2.0.0"
     },
     "is-typedarray": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "is-yarn-global": {
       "version": "0.3.0",
@@ -8986,9 +8629,6 @@
     "isobject": {
       "version": "3.0.1",
       "dev": true
-    },
-    "isstream": {
-      "version": "0.1.2"
     },
     "jest-worker": {
       "version": "26.6.2",
@@ -9024,9 +8664,6 @@
         "esprima": "^4.0.0"
       }
     },
-    "jsbn": {
-      "version": "0.1.1"
-    },
     "json-buffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
@@ -9043,33 +8680,19 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
     },
-    "json-schema": {
-      "version": "0.2.3"
-    },
     "json-schema-traverse": {
-      "version": "0.4.1"
+      "version": "0.4.1",
+      "dev": true
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "dev": true
-    },
-    "json-stringify-safe": {
-      "version": "5.0.1"
     },
     "json5": {
       "version": "2.2.0",
       "dev": true,
       "requires": {
         "minimist": "^1.2.5"
-      }
-    },
-    "jsprim": {
-      "version": "1.4.1",
-      "requires": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
-        "verror": "1.10.0"
       }
     },
     "just-extend": {
@@ -9388,10 +9011,12 @@
       }
     },
     "mime-db": {
-      "version": "1.46.0"
+      "version": "1.46.0",
+      "dev": true
     },
     "mime-types": {
       "version": "2.1.29",
+      "dev": true,
       "requires": {
         "mime-db": "1.46.0"
       }
@@ -9772,9 +9397,6 @@
         "path-key": "^3.0.0"
       }
     },
-    "oauth-sign": {
-      "version": "0.9.0"
-    },
     "once": {
       "version": "1.4.0",
       "requires": {
@@ -10008,9 +9630,6 @@
       "version": "4.0.0",
       "dev": true
     },
-    "performance-now": {
-      "version": "2.1.0"
-    },
     "picomatch": {
       "version": "2.2.2",
       "dev": true
@@ -10056,9 +9675,6 @@
       "version": "1.0.1",
       "dev": true
     },
-    "psl": {
-      "version": "1.8.0"
-    },
     "pump": {
       "version": "3.0.0",
       "requires": {
@@ -10067,7 +9683,8 @@
       }
     },
     "punycode": {
-      "version": "2.1.1"
+      "version": "2.1.1",
+      "dev": true
     },
     "pupa": {
       "version": "2.1.1",
@@ -10077,9 +9694,6 @@
       "requires": {
         "escape-goat": "^2.0.0"
       }
-    },
-    "qs": {
-      "version": "6.5.2"
     },
     "randombytes": {
       "version": "2.1.0",
@@ -10246,31 +9860,6 @@
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
     },
-    "request": {
-      "version": "2.88.2",
-      "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      }
-    },
     "require-directory": {
       "version": "2.1.1",
       "dev": true
@@ -10378,10 +9967,12 @@
       }
     },
     "safe-buffer": {
-      "version": "5.2.0"
+      "version": "5.2.0",
+      "dev": true
     },
     "safer-buffer": {
-      "version": "2.1.2"
+      "version": "2.1.2",
+      "dev": true
     },
     "schema-utils": {
       "version": "3.0.0",
@@ -10542,20 +10133,6 @@
     "sprintf-js": {
       "version": "1.0.3",
       "dev": true
-    },
-    "sshpk": {
-      "version": "1.16.1",
-      "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      }
     },
     "string_decoder": {
       "version": "1.1.1",
@@ -10730,13 +10307,6 @@
       "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
       "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w=="
     },
-    "tough-cookie": {
-      "version": "2.5.0",
-      "requires": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      }
-    },
     "trough": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
@@ -10824,15 +10394,6 @@
       "version": "1.9.3",
       "dev": true
     },
-    "tunnel-agent": {
-      "version": "0.6.0",
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "tweetnacl": {
-      "version": "0.14.5"
-    },
     "type-check": {
       "version": "0.4.0",
       "dev": true,
@@ -10916,14 +10477,6 @@
         "unist-util-is": "^4.0.0"
       }
     },
-    "universal-analytics": {
-      "version": "0.4.20",
-      "requires": {
-        "debug": "^3.0.0",
-        "request": "^2.88.0",
-        "uuid": "^3.0.0"
-      }
-    },
     "update-notifier": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-4.1.3.tgz",
@@ -10998,6 +10551,7 @@
     },
     "uri-js": {
       "version": "4.2.2",
+      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -11039,14 +10593,6 @@
       "dev": true,
       "requires": {
         "builtins": "^1.0.3"
-      }
-    },
-    "verror": {
-      "version": "1.10.0",
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
       }
     },
     "vfile": {

--- a/package.json
+++ b/package.json
@@ -422,7 +422,6 @@
     "webpack-cli": "^4.5.0"
   },
   "dependencies": {
-    "@types/universal-analytics": "^0.4.4",
     "byline": "^5.0.0",
     "compare-versions": "^3.6.0",
     "execa": "^4.0.0",
@@ -431,7 +430,6 @@
     "proxyquire": "^2.1.3",
     "remark-gfm": "^1.0.0",
     "toml": "^3.0.0",
-    "universal-analytics": "^0.4.20",
     "uuid": "^3.4.0",
     "vscode-languageclient": "^6.1.3",
     "vscode-languageserver": "^6.1.1",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,10 +1,5 @@
 import {Disposable, ExtensionContext, commands, debug, env, window, workspace} from 'vscode';
-import {
-  GATelemetry,
-  NoOpTelemetry,
-  StripeAnalyticsServiceTelemetry,
-  TelemetryMigration,
-} from './telemetry';
+import {NoOpTelemetry, StripeAnalyticsServiceTelemetry} from './telemetry';
 import {ServerOptions, TransportKind} from 'vscode-languageclient';
 import {Commands} from './commands';
 import {Git} from './git';
@@ -152,9 +147,6 @@ function getTelemetry(extensionContext: ExtensionContext) {
     console.log('Extension is running in development mode. Not emitting Telemetry');
     return new NoOpTelemetry();
   } else {
-    return new TelemetryMigration(
-      GATelemetry.getInstance(),
-      new StripeAnalyticsServiceTelemetry(extensionContext),
-    );
+    return new StripeAnalyticsServiceTelemetry(extensionContext);
   }
 }

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -3,7 +3,6 @@ import * as queryString from 'querystring';
 import * as vscode from 'vscode';
 import {getCliVersion, getStripeAccountId} from './stripeWorkspaceState';
 import {getExtensionInfo} from './utils';
-import ua from 'universal-analytics';
 import {v4 as uuidv4} from 'uuid';
 
 const osName = require('os-name');
@@ -42,101 +41,6 @@ export class LocalTelemetry implements Telemetry {
 
   isTelemetryEnabled() {
     return true;
-  }
-}
-
-// Google Auth Implementation of Telemetry
-export class GATelemetry implements Telemetry {
-  private static INSTANCE: GATelemetry;
-
-  client: any;
-  userId: string;
-  private _isTelemetryEnabled: boolean;
-
-  private constructor() {
-    this.userId = vscode.env.machineId;
-    this._isTelemetryEnabled = areAllTelemetryConfigsEnabled();
-    this.setup();
-    vscode.workspace.onDidChangeConfiguration(this.configurationChanged, this);
-  }
-
-  public static getInstance(): Telemetry {
-    if (!GATelemetry.INSTANCE) {
-      GATelemetry.INSTANCE = new GATelemetry();
-    }
-
-    return GATelemetry.INSTANCE;
-  }
-
-  isTelemetryEnabled(): boolean {
-    return this._isTelemetryEnabled;
-  }
-
-  setup() {
-    if (!this.isTelemetryEnabled()) {
-      return;
-    }
-
-    if (this.client) {
-      return;
-    }
-
-    this.client = ua('UA-12675062-9');
-
-    const extensionInfo = getExtensionInfo();
-
-    // User custom dimensions to store user metadata
-    this.client.set('cd1', vscode.env.sessionId);
-    this.client.set('cd2', vscode.env.language);
-    this.client.set('cd3', vscode.version);
-    this.client.set('cd4', osName());
-    this.client.set('cd5', extensionInfo.version);
-
-    // Set userID
-    this.client.set('uid', this.userId);
-  }
-
-  sendEvent(eventName: string, eventValue?: any) {
-    if (!this.isTelemetryEnabled()) {
-      return;
-    }
-
-    const requestParams = {
-      eventCategory: 'All',
-      eventAction: eventName,
-      //   eventLabel: "",
-      eventValue: eventValue,
-      uid: this.userId,
-    };
-
-    this.client.event(requestParams).send();
-  }
-
-  private configurationChanged(e: vscode.ConfigurationChangeEvent) {
-    this._isTelemetryEnabled = areAllTelemetryConfigsEnabled();
-    if (this._isTelemetryEnabled) {
-      this.setup();
-    }
-  }
-}
-
-// Temporary class that will allow us to send telemetry data to both locations
-export class TelemetryMigration implements Telemetry {
-  private _gaTelemetry: Telemetry;
-  private _stripeTelemetry: Telemetry;
-
-  constructor(gaTelemetry: Telemetry, stripeTelemetry: Telemetry) {
-    this._gaTelemetry = gaTelemetry;
-    this._stripeTelemetry = stripeTelemetry;
-  }
-
-  isTelemetryEnabled(): boolean {
-    return this._gaTelemetry.isTelemetryEnabled() && this._stripeTelemetry.isTelemetryEnabled();
-  }
-
-  sendEvent(eventName: string, eventValue?: any) {
-    this._gaTelemetry.sendEvent(eventName, eventValue);
-    this._stripeTelemetry.sendEvent(eventName, eventValue);
   }
 }
 

--- a/test/suite/telemetry.test.ts
+++ b/test/suite/telemetry.test.ts
@@ -1,7 +1,7 @@
 import * as assert from 'assert';
 
 import * as vscode from 'vscode';
-import {GATelemetry, StripeAnalyticsServiceTelemetry} from '../../src/telemetry';
+import {StripeAnalyticsServiceTelemetry} from '../../src/telemetry';
 import {mocks} from '../mocks/vscode';
 import sinon from 'ts-sinon';
 
@@ -17,32 +17,6 @@ suite('GATelemetry', function () {
 
   teardown(() => {
     sandbox.restore();
-  });
-
-  suite('Telemetry configs', () => {
-    test('Respects overall and Stripe-specific telemetry configs', () => {
-      const getConfigurationStub = sandbox.stub(vscode.workspace, 'getConfiguration');
-
-      [
-        [false, false, false],
-        [false, true, false],
-        [true, false, false],
-        [true, true, true],
-      ].forEach(async ([telemetryEnabled, stripeTelemetryEnabled, expected]) => {
-        getConfigurationStub.withArgs('telemetry').returns(<any>{
-          get: sandbox.stub().withArgs('telemetryEnabled').returns(telemetryEnabled),
-        });
-        getConfigurationStub
-          .withArgs('stripe.telemetry')
-          .returns(<any>{get: sandbox.stub().withArgs('enabled').returns(stripeTelemetryEnabled)});
-
-        // Simulate a config change
-        await vscode.workspace.getConfiguration('telemetry').update('stripe', undefined);
-        const telemetry = GATelemetry.getInstance();
-
-        assert.strictEqual(telemetry.isTelemetryEnabled(), expected);
-      });
-    });
   });
 });
 


### PR DESCRIPTION
Transition to using the in-house analytics service has been live for a few weeks now, removing Google Analytics as a telemetry destination. 