### PR TITLE
Update events buttons

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -9,7 +9,7 @@ import {
   setConnectWebhookEndpoint,
   setWebhookEndpoint,
 } from './stripeWorkspaceState';
-import {getExtensionInfo, showQuickPickWithItems, showQuickPickWithValues} from './utils';
+import {getExtensionInfo, showQuickPickWithItems} from './utils';
 import osName = require('os-name');
 import {StripeEventsViewProvider} from './stripeEventsView';
 import {StripeLogsViewProvider} from './stripeLogsView';
@@ -89,13 +89,7 @@ export class Commands {
   openWebhooksListen = async (options: any) => {
     this.telemetry.sendEvent('openWebhooksListen');
 
-    const shouldPromptForURL =
-      !options?.forwardTo &&
-      !options?.forwardConnectTo &&
-      (await showQuickPickWithValues(
-        'Do you want to forward webhook events to your local server?',
-        ['Yes', 'No'],
-      )) === 'Yes';
+    const shouldPromptForURL = !options?.forwardTo && !options?.forwardConnectTo;
 
     const [forwardTo, forwardConnectTo] = await (async () => {
       if (!shouldPromptForURL) {

--- a/src/stripeEventsView.ts
+++ b/src/stripeEventsView.ts
@@ -40,7 +40,7 @@ export class StripeEventsViewProvider extends StreamingViewDataProvider {
 
   buildEventsTree(): StripeTreeItem[] {
     const treeItems = [
-      this.getStreamingControlItem('Events', 'startEventsStreaming', 'stopEventsStreaming'),
+      this.getStreamingControlItem('events', 'startEventsStreaming', 'stopEventsStreaming'),
     ];
 
     if (this.streamingTreeItems.length > 0) {
@@ -60,9 +60,11 @@ export class StripeEventsViewProvider extends StreamingViewDataProvider {
       iconPath: new vscode.ThemeIcon('add'),
     });
 
-    const webhooksListenItem = new StripeTreeItem('Start webhooks listening', {
+    const webhooksListenItem = new StripeTreeItem('Forward events to your local machine', {
       commandString: 'openWebhooksListen',
       iconPath: new vscode.ThemeIcon('terminal'),
+      tooltip:
+        "Forward webhook events from Stripe to your local machine by connecting directly to Stripe's API.",
     });
 
     const items = [triggerEventItem, webhooksListenItem, ...eventsItem];

--- a/src/stripeEventsView.ts
+++ b/src/stripeEventsView.ts
@@ -63,8 +63,7 @@ export class StripeEventsViewProvider extends StreamingViewDataProvider {
     const webhooksListenItem = new StripeTreeItem('Forward events to your local machine', {
       commandString: 'openWebhooksListen',
       iconPath: new vscode.ThemeIcon('terminal'),
-      tooltip:
-        "Forward webhook events from Stripe to your local machine by connecting directly to Stripe's API.",
+      tooltip: "Forward webhook events from Stripe's API to your local machine.",
     });
 
     const items = [triggerEventItem, webhooksListenItem, ...eventsItem];


### PR DESCRIPTION
- Changed command name: **Start webhooks listening** ->  **Forward events to your local machine** (closes #70)
- Added a tooltip on hover: "Forward webhook events from Stripe to your local machine by connecting directly to Stripe's API." (fixes #113)
- Because we changed the name of the button to be "Forward events ...", remove the prompt that asks if you want to forward events (because obviously you do)
- Lowercased for consistency: **Start streaming Events** -> **Start streaming events**

Before:
![Screen Shot 2021-05-17 at 4 20 45 PM](https://user-images.githubusercontent.com/71457708/118568138-0aa59580-b72c-11eb-996c-9bd0a14357ef.png)

After:
![Screen Shot 2021-05-17 at 4 20 28 PM](https://user-images.githubusercontent.com/71457708/118568141-0bd6c280-b72c-11eb-8609-01093f3f544c.png)
