### PR TITLE
For `stripe.openWebhooksListen`, allow skipping certificate verification for https URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -331,6 +331,11 @@
                 "type": "array",
                 "markdownDescription": "An array of specific events to listen for. For a list of all possible events, see: https://stripe.com/docs/api/events/types (default: listen for all events)",
                 "default": []
+              },
+              "skipVerify": {
+                "type": "boolean",
+                "description": "Skip certificate verification when forwarding to HTTPS endpoints",
+                "default": false
               }
             }
           }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -127,6 +127,16 @@ export class Commands {
       return;
     }
 
+    const skipVerify = await (async () => {
+      if ([forwardTo, forwardConnectTo].some((url) => url.startsWith('https'))) {
+        const selected = await vscode.window.showQuickPick(['Yes', 'No'], {
+          placeHolder: 'Skip SSL certificate verification?',
+        });
+        return selected === 'Yes';
+      }
+      return false;
+    })();
+
     if (Array.isArray(options?.events)) {
       const invalidEventCharsRE = /[^a-z_.]/;
       const invalidEvent = options.events.find((e: string) => invalidEventCharsRE.test(e));
@@ -146,7 +156,14 @@ export class Commands {
         ? ['--events', options.events.join(',')]
         : [];
 
-    this.terminal.execute('listen', [...forwardToFlag, ...forwardConnectToFlag, ...eventsFlag]);
+    const skipVerifyFlag = skipVerify ? ['--skip-verify'] : [];
+
+    this.terminal.execute('listen', [
+      ...forwardToFlag,
+      ...forwardConnectToFlag,
+      ...eventsFlag,
+      ...skipVerifyFlag,
+    ]);
   };
 
   startEventsStreaming = (stripeEventsViewProvider: StripeEventsViewProvider) => {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -128,13 +128,18 @@ export class Commands {
     }
 
     const skipVerify = await (async () => {
-      if ([forwardTo, forwardConnectTo].some((url) => url.startsWith('https'))) {
-        const selected = await vscode.window.showQuickPick(['Yes', 'No'], {
-          placeHolder: 'Skip SSL certificate verification?',
-        });
-        return selected === 'Yes';
+      if (options.skipVerify !== undefined) {
+        return options.skipVerify;
       }
-      return false;
+
+      if (![forwardTo, forwardConnectTo].some((url) => url.startsWith('https'))) {
+        return false;
+      }
+
+      const selected = await vscode.window.showQuickPick(['Yes', 'No'], {
+        placeHolder: 'Skip SSL certificate verification?',
+      });
+      return selected === 'Yes';
     })();
 
     if (Array.isArray(options?.events)) {

--- a/src/stripeDebugProvider.ts
+++ b/src/stripeDebugProvider.ts
@@ -32,6 +32,7 @@ export class StripeDebugProvider implements vscode.DebugConfigurationProvider {
           forwardTo: config.forwardTo,
           forwardConnectTo: config.forwardConnectTo,
           events: config.events,
+          skipVerify: config.skipVerify,
         });
       }
     } else {


### PR DESCRIPTION
### Summary

fixes #169 

- When clicking **Forward events to your local machine**, when a user provides any URL that starts with https, ask if they want to skip certificate verification.
- For the debug configuration, add a `skipVerify` option that can be set in the launch.json.

Tested manually.

### Screenshots

**Forward events to your local machine**:

https://user-images.githubusercontent.com/71457708/120684026-1d6dd900-c453-11eb-84ae-b18204e4db59.mov

Debugger config:

https://user-images.githubusercontent.com/71457708/120683847-f1eaee80-c452-11eb-8a8e-58e89981323d.mov
