### PR TITLE
Linter Updates: Ignore .env files and redacted keys 

### DIFF
--- a/test/suite/stripeLinter.test.ts
+++ b/test/suite/stripeLinter.test.ts
@@ -36,6 +36,28 @@ suite('StripeLinter', () => {
       assert.strictEqual(diagnostics.length, 0);
     });
 
+    test('Editor content is not searched on .env files', async () => {
+      const setting = vscode.Uri.parse('untitled:.env');
+      const doc = await vscode.workspace.openTextDocument(setting);
+
+      await vscode.window
+        .showTextDocument(doc)
+        .then((editor) =>
+          editor.edit((builder) => builder.insert(new vscode.Position(0, 0), 'sk_live_1234')),
+        );
+
+      const isIgnoredStub = sandbox.stub(git, 'isIgnored').resolves(false);
+      const telemetrySpy = sandbox.spy(telemetry, 'sendEvent');
+
+      const linter = new StripeLinter(telemetry, git);
+      await linter.activate();
+
+      const diagnostics = vscode.languages.getDiagnostics(doc.uri);
+      assert.strictEqual(isIgnoredStub.calledOnce, true);
+      assert.strictEqual(telemetrySpy.callCount, 0);
+      assert.strictEqual(diagnostics.length, 0);
+    });
+
     test('Diagnostics are pushed when linter finds offenses', async () => {
       const options = {content: 'I have content with critical data : sk_live_1234'};
       const document = await vscode.workspace.openTextDocument(options);
@@ -59,6 +81,23 @@ suite('StripeLinter', () => {
 
     test('No diagnostics are pushed when file is clean', async () => {
       const options = {content: 'I am a good file'};
+      const document = await vscode.workspace.openTextDocument(options);
+      await vscode.window.showTextDocument(document, {preview: false});
+
+      const isIgnoredStub = sandbox.stub(git, 'isIgnored').resolves(false);
+      const telemetrySpy = sandbox.spy(telemetry, 'sendEvent');
+
+      const linter = new StripeLinter(telemetry, git);
+      await linter.activate();
+      const diagnostics: vscode.Diagnostic[] = vscode.languages.getDiagnostics(document.uri);
+
+      assert.strictEqual(isIgnoredStub.calledOnce, true);
+      assert.strictEqual(telemetrySpy.callCount, 0);
+      assert.strictEqual(diagnostics.length, 0);
+    });
+
+    test('Diagnostics are not pushed when redacted keys are present', async () => {
+      const options = {content: 'I have redacted keys : sk_live_aa********************1234'};
       const document = await vscode.workspace.openTextDocument(options);
       await vscode.window.showTextDocument(document, {preview: false});
 


### PR DESCRIPTION
The redaction change is targeted to protect against the specific redacted format that Stripe returns which looks something like "sk_live_aa********************1234".
It does not attempt to detect other potential ways users can modify the keys  nor actually validate that the key is real.

This change fixes https://github.com/stripe/vscode-stripe/issues/220 and https://github.com/stripe/vscode-stripe/issues/222

# Testing
.env file before:
![Screen Shot 2021-06-03 at 2 15 51 PM](https://user-images.githubusercontent.com/75757829/120718198-c03b4d00-c47d-11eb-9d9c-39064bbb04a5.png)

after:
![Screen Shot 2021-06-03 at 2 25 26 PM](https://user-images.githubusercontent.com/75757829/120718202-c29da700-c47d-11eb-950e-990b75b8f697.png)

redacted keys before:
![Screen Shot 2021-06-03 at 3 24 33 PM](https://user-images.githubusercontent.com/75757829/120719821-ce8a6880-c47f-11eb-974d-90d77d2ee826.png)

after:
![Screen Shot 2021-06-03 at 3 11 06 PM](https://user-images.githubusercontent.com/75757829/120718286-efea5500-c47d-11eb-97e4-1675e78bc79d.png)


