### PR TITLE
Hides views when on the welcome view

### DIFF
--- a/package.json
+++ b/package.json
@@ -233,11 +233,13 @@
         },
         {
           "id": "stripeQuickLinksView",
-          "name": "Quick Links"
+          "name": "Quick Links",
+          "when": "stripe.isNotCLIInstalled == false"
         },
         {
           "id": "stripeHelpView",
-          "name": "Help and feedback"
+          "name": "Help and feedback",
+          "when": "stripe.isNotCLIInstalled == false"
         }
       ]
     },


### PR DESCRIPTION
### Summary

r? @vcheung-stripe 
cc? @stripe/developer-products

fixes #244 

Hide the quick links and feedback sections when the user doesn't have the StripeCLI installed. When the user doesn't have it installed we show the welcome view. 

### Screenshots

When the CLI is uninstalled: 

<img width="2839" alt="Screen Shot 2021-06-07 at 11 48 52 AM" src="https://user-images.githubusercontent.com/49962232/121074841-3fd06100-c789-11eb-89ca-e64112164830.png">

When the CLI is installed: 

<img width="2836" alt="Screen Shot 2021-06-07 at 11 49 53 AM" src="https://user-images.githubusercontent.com/49962232/121074976-7312f000-c789-11eb-859a-bb42f1092aec.png">
