### PR TITLE
Adding null check for skipverify

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -128,7 +128,7 @@ export class Commands {
     }
 
     const skipVerify = await (async () => {
-      if (options.skipVerify !== undefined) {
+      if (options?.skipVerify !== undefined) {
         return options.skipVerify;
       }
 


### PR DESCRIPTION
### Summary

When you launch cmd+shift+p and run “Start webhooks event listening” the options can be null because the user will type them in. This adds a null check. 

###Testing 

Verified manually without check: 

<img width="1329" alt="Screen Shot 2021-06-07 at 4 22 06 PM" src="https://user-images.githubusercontent.com/49962232/121099621-07db1500-c7ad-11eb-87af-1d73e3d72b9e.png">

With check everything runs: 

<img width="1326" alt="Screen Shot 2021-06-07 at 4 22 59 PM" src="https://user-images.githubusercontent.com/49962232/121099630-0f022300-c7ad-11eb-892b-a8d096bc4ec9.png">

r? @vcheung-stripe 
cc @stripe/developer-products 