### PR TITLE
Fix naming

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,12 +94,12 @@
       {
         "category": "Stripe",
         "command": "stripe.createStripeSample",
-        "title": "Clone a sample integration built by Stripe"
+        "title": "Start with a Stripe sample"
       },
       {
         "category": "Stripe",
         "command": "stripe.openWebhooksListen",
-        "title": "Start Webhooks events listening with CLI"
+        "title": "Forward webhook events to your local machine"
       },
       {
         "category": "Stripe",
@@ -109,17 +109,17 @@
       {
         "category": "Stripe",
         "command": "stripe.startEventsStreaming",
-        "title": "Start streaming Events"
+        "title": "Start streaming events"
       },
       {
         "category": "Stripe",
         "command": "stripe.stopEventsStreaming",
-        "title": "Stop streaming Events"
+        "title": "Stop streaming events"
       },
       {
         "category": "Stripe",
         "command": "stripe.startLogsStreaming",
-        "title": "Start streaming API logs "
+        "title": "Start streaming API logs"
       },
       {
         "category": "Stripe",
@@ -139,7 +139,7 @@
       {
         "category": "Stripe",
         "command": "stripe.openDashboardApikeys",
-        "title": "Open Dashboard to manage API Keys"
+        "title": "Open Dashboard to manage API keys"
       },
       {
         "category": "Stripe",
@@ -159,12 +159,12 @@
       {
         "category": "Stripe",
         "command": "stripe.openDashboardEvents",
-        "title": "Open Dashboard to see recent Events"
+        "title": "Open Dashboard to see recent events"
       },
       {
         "category": "Stripe",
         "command": "stripe.openDashboardWebhooks",
-        "title": "Open Dashboard to manage Webhooks"
+        "title": "Open Dashboard to manage webhooks"
       },
       {
         "category": "Stripe",

--- a/src/stripeQuickLinksView.ts
+++ b/src/stripeQuickLinksView.ts
@@ -6,7 +6,7 @@ export class StripeQuickLinksViewProvider extends StripeTreeViewDataProvider {
   buildTree(): Promise<StripeTreeItem[]> {
     const items = [];
 
-    const samplesItem = new StripeTreeItem('Start with a Stripe Sample', {
+    const samplesItem = new StripeTreeItem('Start with a Stripe sample', {
       commandString: 'createStripeSample',
       iconPath: new ThemeIcon('repo-clone'),
       tooltip: 'Clone a sample integration built by Stripe',


### PR DESCRIPTION
### Summary

the command palette equivalent of Stripe samples should be: "Start with a Stripe Sample" to match what shows up in the panel.
Change the Command Palette text from “Start webhooks events listening with CLI” to “Forward webhook events to your local machine”, so that the UI ~ aligns
“events”, “API keys”, and “webhooks” should all be lowercase in the command palette
“Start with a Stripe sample” ← lowercase Sample


### Testing

Manually tested 

<img width="437" alt="Screen Shot 2021-06-07 at 4 43 43 PM" src="https://user-images.githubusercontent.com/49962232/121100915-a23c5800-c7af-11eb-8ce3-38363e47e510.png">


r? @gracegoo-stripe 

fixes #250 
