### PR TITLE
Moving stripe samples to it's own menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -232,14 +232,21 @@
           "when": "stripe.isNotCLIInstalled == false"
         },
         {
+          "id": "stripeSamplesView",
+          "name": "Samples",
+          "when": "stripe.isNotCLIInstalled == false"
+        },
+        {
           "id": "stripeQuickLinksView",
           "name": "Quick Links",
-          "when": "stripe.isNotCLIInstalled == false"
+          "when": "stripe.isNotCLIInstalled == false",
+          "visibility": "collapsed"
         },
         {
           "id": "stripeHelpView",
           "name": "Help and feedback",
-          "when": "stripe.isNotCLIInstalled == false"
+          "when": "stripe.isNotCLIInstalled == false",
+          "visibility": "collapsed"
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -281,6 +281,10 @@
         {
           "command": "stripe.openDashboardLogFromTreeItemContextMenu",
           "when": "viewItem == logItem"
+        },
+        {
+          "command": "stripe.openSamples",
+          "when": "viewItem == samplesItem"
         }
       ],
       "commandPalette": [

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -128,7 +128,7 @@ export class Commands {
     }
 
     const skipVerify = await (async () => {
-      if (options.skipVerify !== undefined) {
+      if (options?.skipVerify !== undefined) {
         return options.skipVerify;
       }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,12 +14,12 @@ import {StripeLinter} from './stripeLinter';
 import {StripeLogsViewProvider} from './stripeLogsView';
 import {StripeQuickLinksViewProvider} from './stripeQuickLinksView';
 import {StripeSamples} from './stripeSamples';
+import {StripeSamplesViewProvider} from './stripeSamplesView';
 import {StripeTerminal} from './stripeTerminal';
 import {SurveyPrompt} from './surveyPrompt';
 import {TelemetryPrompt} from './telemetryPrompt';
 import {initializeStripeWorkspaceState} from './stripeWorkspaceState';
 import path from 'path';
-import {StripeSamplesViewProvider} from './stripeSamplesView';
 
 export function activate(this: any, context: ExtensionContext) {
   initializeStripeWorkspaceState(context);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,6 +19,7 @@ import {SurveyPrompt} from './surveyPrompt';
 import {TelemetryPrompt} from './telemetryPrompt';
 import {initializeStripeWorkspaceState} from './stripeWorkspaceState';
 import path from 'path';
+import {StripeSamplesViewProvider} from './stripeSamplesView';
 
 export function activate(this: any, context: ExtensionContext) {
   initializeStripeWorkspaceState(context);
@@ -46,6 +47,11 @@ export function activate(this: any, context: ExtensionContext) {
   window.createTreeView('stripeLogsView', {
     treeDataProvider: stripeLogsViewProvider,
     showCollapseAll: true,
+  });
+
+  window.createTreeView('stripeSamplesView', {
+    treeDataProvider: new StripeSamplesViewProvider(),
+    showCollapseAll: false,
   });
 
   window.createTreeView('stripeQuickLinksView', {

--- a/src/stripeHelpView.ts
+++ b/src/stripeHelpView.ts
@@ -12,13 +12,6 @@ export class StripeHelpViewProvider extends StripeTreeViewDataProvider {
     });
     items.push(docsItem);
 
-    const samplesItem = new StripeTreeItem('Find code samples', {
-      commandString: 'openSamples',
-      iconPath: new ThemeIcon('code'),
-      tooltip: 'Sample integrations built by Stripe',
-    });
-    items.push(samplesItem);
-
     const reportItem = new StripeTreeItem('Report issue', {
       commandString: 'openReportIssue',
       iconPath: new ThemeIcon('report'),

--- a/src/stripeQuickLinksView.ts
+++ b/src/stripeQuickLinksView.ts
@@ -6,14 +6,6 @@ export class StripeQuickLinksViewProvider extends StripeTreeViewDataProvider {
   buildTree(): Promise<StripeTreeItem[]> {
     const items = [];
 
-    const samplesItem = new StripeTreeItem('Start with a Stripe Sample', {
-      commandString: 'createStripeSample',
-      iconPath: new ThemeIcon('repo-clone'),
-      tooltip: 'Clone a sample integration built by Stripe',
-    });
-
-    items.push(samplesItem);
-
     const apiKeysItem = new StripeTreeItem('Open API keys page', {
       commandString: 'openDashboardApikeys',
       iconPath: new ThemeIcon('link-external'),

--- a/src/stripeSamplesView.ts
+++ b/src/stripeSamplesView.ts
@@ -1,0 +1,19 @@
+import {StripeTreeItem} from './stripeTreeItem';
+import {StripeTreeViewDataProvider} from './stripeTreeViewDataProvider';
+import {ThemeIcon} from 'vscode';
+
+export class StripeSamplesViewProvider extends StripeTreeViewDataProvider {
+  buildTree(): Promise<StripeTreeItem[]> {
+    const items = [];
+
+    const samplesItem = new StripeTreeItem('Start with a Stripe Sample', {
+      commandString: 'createStripeSample',
+      iconPath: new ThemeIcon('repo-clone'),
+      tooltip: 'Clone a sample integration built by Stripe',
+    });
+
+    items.push(samplesItem);
+
+    return Promise.resolve(items);
+  }
+}

--- a/src/stripeSamplesView.ts
+++ b/src/stripeSamplesView.ts
@@ -14,6 +14,13 @@ export class StripeSamplesViewProvider extends StripeTreeViewDataProvider {
 
     items.push(samplesItem);
 
+    const findSamplesItem = new StripeTreeItem('Find code samples', {
+      commandString: 'openSamples',
+      iconPath: new ThemeIcon('code'),
+      tooltip: 'Sample integrations built by Stripe',
+    });
+    items.push(findSamplesItem);
+
     return Promise.resolve(items);
   }
 }

--- a/src/stripeSamplesView.ts
+++ b/src/stripeSamplesView.ts
@@ -10,16 +10,10 @@ export class StripeSamplesViewProvider extends StripeTreeViewDataProvider {
       commandString: 'createStripeSample',
       iconPath: new ThemeIcon('repo-clone'),
       tooltip: 'Clone a sample integration built by Stripe',
+      contextValue: 'samplesItem',
     });
 
     items.push(samplesItem);
-
-    const findSamplesItem = new StripeTreeItem('Find code samples', {
-      commandString: 'openSamples',
-      iconPath: new ThemeIcon('code'),
-      tooltip: 'Sample integrations built by Stripe',
-    });
-    items.push(findSamplesItem);
 
     return Promise.resolve(items);
   }


### PR DESCRIPTION
### Summary 

- Move the samples out into its own view. Panel should be: Events, Logs, Samples, Quick Links, Help and Feedback
- Auto-collapse the quick links and help and feedback section.
- Remove "Find code samples" from the help and feedback link. This belongs in the context of the Stripe Samples workflow.

### Testing 

Manually tested:

<img width="522" alt="Screen Shot 2021-06-07 at 5 30 40 PM" src="https://user-images.githubusercontent.com/49962232/121104079-1d087180-c7b6-11eb-8593-11fe17c829a2.png">
<img width="533" alt="Screen Shot 2021-06-07 at 5 30 36 PM" src="https://user-images.githubusercontent.com/49962232/121104081-1da10800-c7b6-11eb-9782-616423c9d0da.png">

fixes #249 
r? @vcheung-stripe 
