### PR TITLE
Updating the text for the webhooks prompt

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -100,12 +100,13 @@ export class Commands {
       const defaultForwardToURL = 'http://localhost:3000';
 
       const forwardToInput = await vscode.window.showInputBox({
-        prompt: 'Enter local server URL to forward webhook events to',
+        prompt:
+          '[Account events] Enter local server URL to forward webhook events from your account',
         value: getWebhookEndpoint(this.context) || defaultForwardToURL,
       });
       const forwardConnectToInput = await vscode.window.showInputBox({
         prompt:
-          'Enter local server URL to forward Connect webhook events to (default: same as normal events)',
+          '[Connect events] Enter local server URL to forward events from Connect applications (default: same URL as normal events)',
         value: getConnectWebhookEndpoint(this.context) || forwardToInput,
       });
 


### PR DESCRIPTION
<img width="916" alt="Screen Shot 2021-06-09 at 5 07 24 PM" src="https://user-images.githubusercontent.com/49962232/121444922-47d50000-c945-11eb-8369-d34ba56da4da.png">

<img width="1044" alt="Screen Shot 2021-06-09 at 5 07 20 PM" src="https://user-images.githubusercontent.com/49962232/121444923-49062d00-c945-11eb-9ae9-aea9308794e6.png">

r? @vcheung-stripe 


fixes #248 updating the text to show connect vs account more prominently. Given a lack of better UX text is all we can do unless we go full custom.  