### PR TITLE
Add publishing step for dotnet language server

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -33,15 +33,9 @@
     },
     {
       "label": "build dotnet server",
-      "command": "dotnet",
-      "type": "process",
-      "args": [
-          "build",
-          "${workspaceFolder}/src/stripeDotnetLanguageServer/stripe.LanguageServer/stripe.LanguageServer.csproj",
-          "/property:GenerateFullPaths=true",
-          "/consoleloggerparameters:NoSummary"
-      ],
-      "problemMatcher": "$msCompile"
+      "type": "npm",
+      "script": "publish:dotnet-server",
+      "isBackground": true
   },
     {
       "label": "Build all",

--- a/package.json
+++ b/package.json
@@ -389,13 +389,14 @@
     "lint": "eslint --ext .ts .",
     "pretest": "npm run compile && npm run webpack-dev",
     "test": "node ./out/test/runTest.js",
-    "vscode:prepublish": "npm run clean && npm run webpack-prod",
+    "vscode:prepublish": "npm run clean && npm run webpack-prod && npm run publish:dotnet-server",
     "webpack-dev:extension": "webpack --mode development --config ./webpack.config.js",
     "webpack-dev:language-server": "webpack --mode development --config ./src/stripeLanguageServer/webpack.config.js",
     "webpack-dev": "npm run webpack-dev:extension && npm run webpack-dev:language-server",
     "webpack-prod:extension": "webpack --mode production --config ./webpack.config.js && webpack --mode production --config ./src/stripeLanguageServer/webpack.config.js",
     "webpack-prod:language-server": "webpack --mode production --config ./src/stripeLanguageServer/webpack.config.js",
-    "webpack-prod": "npm run webpack-prod:extension && npm run webpack-prod:language-server"
+    "webpack-prod": "npm run webpack-prod:extension && npm run webpack-prod:language-server",
+    "publish:dotnet-server": "dotnet publish src/stripeDotnetLanguageServer/stripe.LanguageServer/ -o ./dist/stripeDotnetLanguageServer"
   },
   "devDependencies": {
     "@types/byline": "^4.2.32",

--- a/src/languageServerClient.ts
+++ b/src/languageServerClient.ts
@@ -73,7 +73,7 @@ export class StripeLanguageClient {
     // TODO: replace this with real function that can find the executable
     const dotNetExecutable = '/usr/local/share/dotnet/dotnet';
     const serverAssembly = context.asAbsolutePath(
-      'src/stripeDotnetLanguageServer/stripe.LanguageServer/bin/Debug/net5.0/stripe.LanguageServer.dll',
+      'dist/stripeDotnetLanguageServer/stripe.LanguageServer.dll',
     );
 
     const serverOptions: ServerOptions = {


### PR DESCRIPTION
This commit adds a new npm script target that calls the `dotnet publish` command to place all necessary libs into the dist/stripeDotnetLanguageServer folder which we can then access from the client. We are excluding the test project from being included in the publishing. 

I also updated the task.json as well to use the npm script. 

Note -- this did not need to be an npm script at all, we could have just added a bash script that has the same contents and called it, but I figured it'll just be easier to keep track of if all our build steps were in the same place. 


# Testing 
1. Made sure the language server can startup via the debugger launcher 
2. Packaged up the extension with `vsce package`, manually installed it, and made sure the language server can start up.