### PR TITLE
Fixing Stripe Samples folder opening on Windows

### DIFF
--- a/src/stripeSamples.ts
+++ b/src/stripeSamples.ts
@@ -287,12 +287,12 @@ export class StripeSamples {
 
     switch (selectedOption) {
       case openFolderOptions.sameWindow:
-        await vscode.commands.executeCommand('vscode.openFolder', vscode.Uri.parse(path), {
+        await vscode.commands.executeCommand('vscode.openFolder', vscode.Uri.file(path), {
           forceNewWindow: false,
         });
         break;
       case openFolderOptions.newWindow:
-        await vscode.commands.executeCommand('vscode.openFolder', vscode.Uri.parse(path), {
+        await vscode.commands.executeCommand('vscode.openFolder', vscode.Uri.file(path), {
           forceNewWindow: true,
         });
         break;


### PR DESCRIPTION
From the API doc: 
The *difference* between `Uri#parse` and `Uri#file` is that the latter treats the argument as path, not as stringified-uri.
Also verified that opening samples still works on mac.

Before:
https://user-images.githubusercontent.com/2405770/122610962-5bfbba00-d035-11eb-8661-352549cae4d6.mp4

After:
https://user-images.githubusercontent.com/2405770/122610964-5dc57d80-d035-11eb-8f50-d2c9c16fde5a.mp4

