### PR TITLE
Do not try to acquire dotnet runtime if we are on M1 macs 

### DIFF
--- a/src/languageServerClient.ts
+++ b/src/languageServerClient.ts
@@ -78,7 +78,7 @@ export class StripeLanguageClient {
     outputChannel.appendLine('Detected C# Project file: ' + projectFile);
     const dotnetRuntimeVersion = '5.0';
 
-    // arm64 is not supported for dotnet < 6.0:
+    // Applie Silicon is not supported for dotnet < 6.0:
     // https://github.com/dotnet/core/issues/4879#issuecomment-729046912
     if (getOSType() === OSType.macOSarm) {
       outputChannel.appendLine(`.NET runtime v${dotnetRuntimeVersion} is not supported for M1`);

--- a/test/suite/languageServerClient.test.ts
+++ b/test/suite/languageServerClient.test.ts
@@ -1,0 +1,121 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+import {StripeLanguageClient} from '../../src/languageServerClient';
+
+suite('languageServerClient', () => {
+  let sandbox: sinon.SinonSandbox;
+
+  setup(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  teardown(() => {
+    sandbox.restore();
+  });
+
+  suite('getDotnetProjectFiles', () => {
+    const workspaceRoot = vscode.Uri.file('my/path');
+    const workspacePath = workspaceRoot.path;
+
+    test('returns empty when no workspaces', async () => {
+      sandbox.stub(vscode.workspace, 'workspaceFolders').value([]);
+      const projectFiles = await StripeLanguageClient.getDotnetProjectFiles();
+      assert.deepStrictEqual(projectFiles, []);
+    });
+
+    test('returns empty when workspaceFolder is undefined', async () => {
+      sandbox.stub(vscode.workspace, 'workspaceFolders').value(undefined);
+      const projectFiles = await StripeLanguageClient.getDotnetProjectFiles();
+      assert.deepStrictEqual(projectFiles, []);
+    });
+
+    test('returns sln project if it exists', async () => {
+      const slnFile = vscode.Uri.file('project.sln');
+      sandbox.stub(vscode.workspace, 'workspaceFolders').value([
+        {
+          index: 0,
+          name: 'workspace',
+          uri: vscode.Uri.file(workspacePath),
+        },
+      ]);
+      sandbox.stub(vscode.workspace, 'findFiles').returns(Promise.resolve([slnFile]));
+
+      const projectFiles = await StripeLanguageClient.getDotnetProjectFiles();
+      assert.deepStrictEqual(projectFiles, [slnFile.path]);
+    });
+
+    test('returns csproj if it exists', async () => {
+      const csprojFile = vscode.Uri.file('project.csproj');
+      sandbox.stub(vscode.workspace, 'workspaceFolders').value([
+        {
+          index: 0,
+          name: 'workspace',
+          uri: vscode.Uri.file(workspacePath),
+        },
+      ]);
+      const fileFilesStub = sandbox.stub(vscode.workspace, 'findFiles');
+      fileFilesStub
+        .withArgs(new vscode.RelativePattern(workspacePath, '**/*.sln'))
+        .returns(Promise.resolve([]));
+      fileFilesStub
+        .withArgs(new vscode.RelativePattern(workspacePath, '**/*.csproj'))
+        .returns(Promise.resolve([csprojFile]));
+
+      const projectFiles = await StripeLanguageClient.getDotnetProjectFiles();
+      assert.deepStrictEqual(projectFiles, [csprojFile.path]);
+    });
+
+    test('returns empty when no dotnet projects', async () => {
+      sandbox.stub(vscode.workspace, 'workspaceFolders').value([
+        {
+          index: 0,
+          name: 'workspace',
+          uri: vscode.Uri.file(workspacePath),
+        },
+      ]);
+      const fileFilesStub = sandbox.stub(vscode.workspace, 'findFiles');
+      fileFilesStub.onCall(0).returns(Promise.resolve([]));
+      fileFilesStub.onCall(1).returns(Promise.resolve([]));
+
+      const projectFiles = await StripeLanguageClient.getDotnetProjectFiles();
+      assert.deepStrictEqual(projectFiles, []);
+    });
+
+    test('filters out non-dotnet projects', async () => {
+      const slnFile = vscode.Uri.file('project.sln');
+      const workspacePath1 = vscode.Uri.file('path/to/workspace/1');
+      const workspacePath2 = vscode.Uri.file('path/to/workspace/2');
+
+      sandbox.stub(vscode.workspace, 'workspaceFolders').value([
+        {
+          index: 0,
+          name: 'workspace',
+          uri: workspacePath1,
+        },
+        {
+          index: 1,
+          name: 'another workspace',
+          uri: workspacePath2,
+        },
+      ]);
+      const fileFilesStub = sandbox.stub(vscode.workspace, 'findFiles');
+
+      // first workspace has a solution
+      fileFilesStub
+        .withArgs(new vscode.RelativePattern(workspacePath1.path, '**/*.sln'))
+        .returns(Promise.resolve([slnFile]));
+
+      // second workspace is not a dotnet project
+      fileFilesStub
+        .withArgs(new vscode.RelativePattern(workspacePath2.path, '**/*.sln'))
+        .returns(Promise.resolve([]));
+      fileFilesStub
+        .withArgs(new vscode.RelativePattern(workspacePath2.path, '**/*.csproj'))
+        .returns(Promise.resolve([]));
+
+      const projectFiles = await StripeLanguageClient.getDotnetProjectFiles();
+      assert.deepStrictEqual(projectFiles, [slnFile.path]);
+    });
+  });
+});

--- a/test/suite/languageServerClient.test.ts
+++ b/test/suite/languageServerClient.test.ts
@@ -16,7 +16,9 @@ suite('languageServerClient', () => {
 
   suite('getDotnetProjectFiles', () => {
     const workspaceRoot = vscode.Uri.file('my/path');
-    const workspacePath = workspaceRoot.path;
+    console.log('Path: ' + workspaceRoot.path);
+    console.log('FS Path: ' + workspaceRoot.fsPath);
+    const workspacePath = workspaceRoot.fsPath;
 
     test('returns empty when no workspaces', async () => {
       sandbox.stub(vscode.workspace, 'workspaceFolders').value([]);
@@ -42,7 +44,7 @@ suite('languageServerClient', () => {
       sandbox.stub(vscode.workspace, 'findFiles').returns(Promise.resolve([slnFile]));
 
       const projectFiles = await StripeLanguageClient.getDotnetProjectFiles();
-      assert.deepStrictEqual(projectFiles, [slnFile.path]);
+      assert.deepStrictEqual(projectFiles, [slnFile.fsPath]);
     });
 
     test('returns csproj if it exists', async () => {
@@ -63,7 +65,7 @@ suite('languageServerClient', () => {
         .returns(Promise.resolve([csprojFile]));
 
       const projectFiles = await StripeLanguageClient.getDotnetProjectFiles();
-      assert.deepStrictEqual(projectFiles, [csprojFile.path]);
+      assert.deepStrictEqual(projectFiles, [csprojFile.fsPath]);
     });
 
     test('returns empty when no dotnet projects', async () => {
@@ -103,19 +105,19 @@ suite('languageServerClient', () => {
 
       // first workspace has a solution
       fileFilesStub
-        .withArgs(new vscode.RelativePattern(workspacePath1.path, '**/*.sln'))
+        .withArgs(new vscode.RelativePattern(workspacePath1.fsPath, '**/*.sln'))
         .returns(Promise.resolve([slnFile]));
 
       // second workspace is not a dotnet project
       fileFilesStub
-        .withArgs(new vscode.RelativePattern(workspacePath2.path, '**/*.sln'))
+        .withArgs(new vscode.RelativePattern(workspacePath2.fsPath, '**/*.sln'))
         .returns(Promise.resolve([]));
       fileFilesStub
-        .withArgs(new vscode.RelativePattern(workspacePath2.path, '**/*.csproj'))
+        .withArgs(new vscode.RelativePattern(workspacePath2.fsPath, '**/*.csproj'))
         .returns(Promise.resolve([]));
 
       const projectFiles = await StripeLanguageClient.getDotnetProjectFiles();
-      assert.deepStrictEqual(projectFiles, [slnFile.path]);
+      assert.deepStrictEqual(projectFiles, [slnFile.fsPath]);
     });
   });
 });

--- a/test/suite/languageServerClient.test.ts
+++ b/test/suite/languageServerClient.test.ts
@@ -1,23 +1,139 @@
 import * as assert from 'assert';
 import * as sinon from 'sinon';
+import * as utils from '../../src/utils';
 import * as vscode from 'vscode';
+import {BaseLanguageClient, MessageTransports} from 'vscode-languageclient';
+import {NoOpTelemetry, Telemetry} from '../../src/telemetry';
 import {StripeLanguageClient} from '../../src/languageServerClient';
+import {mocks} from '../mocks/vscode';
 
-suite('languageServerClient', () => {
+const proxyquire = require('proxyquire');
+const modulePath = '../../src/languageServerClient';
+
+const setupProxies = (proxies: any) => proxyquire(modulePath, proxies);
+
+class TestLanguageClient extends BaseLanguageClient {
+  constructor() {
+    super('foo', 'foo', {});
+  }
+  protected createMessageTransports(): Promise<MessageTransports> {
+    throw new Error('Method not implemented.');
+  }
+  start() {
+    return {dispose: () => {}};
+  }
+
+  onReady() {
+    return Promise.resolve();
+  }
+}
+
+const vscodeStub = {
+  LanguageClient: TestLanguageClient,
+};
+
+suite('languageServerClient', function () {
+  this.timeout(20000);
+  let extensionContext: vscode.ExtensionContext;
+  let outputChannel: Partial<vscode.OutputChannel>;
+  let telemetry: Telemetry;
   let sandbox: sinon.SinonSandbox;
 
   setup(() => {
     sandbox = sinon.createSandbox();
+    outputChannel = {appendLine: (value: string) => {}, show: () => {}};
+    extensionContext = {...mocks.extensionContextMock};
+    telemetry = new NoOpTelemetry();
   });
 
   teardown(() => {
     sandbox.restore();
   });
 
+  suite('activateDotNetServer', () => {
+    const module = setupProxies({'vscode-languageclient': vscodeStub});
+    const dotnetPath = '/my/executable/path';
+    let telemetrySpy: sinon.SinonSpy;
+
+    const stubDotnetAcquire = (result: {} | undefined) => {
+      return sandbox
+        .stub(vscode.commands, 'executeCommand')
+        .withArgs('dotnet.acquire', {
+          version: '5.0',
+          requestingExtensionId: 'stripe.vscode-stripe',
+        })
+        .resolves(result);
+    };
+
+    setup(() => {
+      telemetrySpy = sandbox.spy(telemetry, 'sendEvent');
+    });
+
+    test('calls activate on dotnet client', async () => {
+      sandbox.stub(utils, 'getOSType').returns(utils.OSType.macOSintel);
+      const dotnetAcquireStub = stubDotnetAcquire({dotnetPath: dotnetPath});
+      const projectFile = 'project/file.sln';
+
+      await module.StripeLanguageClient.activateDotNetServer(
+        extensionContext,
+        <any>outputChannel,
+        projectFile,
+        telemetry,
+      );
+
+      assert.deepStrictEqual(dotnetAcquireStub.calledOnce, true);
+      assert.deepStrictEqual(
+        telemetrySpy.calledWith('dotnetRuntimeAcquisitionSkippedForM1'),
+        false,
+      );
+      assert.deepStrictEqual(telemetrySpy.calledWith('dotnetRuntimeAcquisitionFailed'), false);
+      assert.deepStrictEqual(telemetrySpy.calledWith('dotnetServerStarted'), true);
+    });
+
+    test('does not start server if on M1', async () => {
+      sandbox.stub(utils, 'getOSType').returns(utils.OSType.macOSarm);
+      const dotnetAcquireStub = stubDotnetAcquire({dotnetPath: dotnetPath});
+
+      const projectFile = 'project/file.sln';
+
+      await module.StripeLanguageClient.activateDotNetServer(
+        extensionContext,
+        <any>outputChannel,
+        projectFile,
+        telemetry,
+      );
+
+      assert.deepStrictEqual(telemetrySpy.calledWith('dotnetRuntimeAcquisitionSkippedForM1'), true);
+      assert.deepStrictEqual(dotnetAcquireStub.calledOnce, false);
+      assert.deepStrictEqual(telemetrySpy.calledWith('dotnetRuntimeAcquisitionFailed'), false);
+      assert.deepStrictEqual(telemetrySpy.calledWith('dotnetServerStarted'), false);
+    });
+
+    test('does not start server error while acquiring dotnet', async () => {
+      sandbox.stub(utils, 'getOSType').returns(utils.OSType.macOSintel);
+      const dotnetAcquireStub = stubDotnetAcquire(undefined);
+
+      const projectFile = 'project/file.sln';
+
+      await module.StripeLanguageClient.activateDotNetServer(
+        extensionContext,
+        <any>outputChannel,
+        projectFile,
+        telemetry,
+      );
+
+      assert.deepStrictEqual(
+        telemetrySpy.calledWith('dotnetRuntimeAcquisitionSkippedForM1'),
+        false,
+      );
+      assert.deepStrictEqual(dotnetAcquireStub.calledOnce, true);
+      assert.deepStrictEqual(telemetrySpy.calledWith('dotnetRuntimeAcquisitionFailed'), true);
+      assert.deepStrictEqual(telemetrySpy.calledWith('dotnetServerStarted'), false);
+    });
+  });
+
   suite('getDotnetProjectFiles', () => {
     const workspaceRoot = vscode.Uri.file('my/path');
-    console.log('Path: ' + workspaceRoot.path);
-    console.log('FS Path: ' + workspaceRoot.fsPath);
     const workspacePath = workspaceRoot.fsPath;
 
     test('returns empty when no workspaces', async () => {


### PR DESCRIPTION
Fixes https://github.com/stripe/vscode-stripe/issues/287.

dotnet < 6.0 is not supported for native M1 so this commit adds a check to not even attempt to acquire it.
Given that dotnet is not supported, we don't expect this path to be hit anyway but adding telemetry to get some numbers.

* Also added some unit tests for this change and also fixed the unit tests for the `getDotnetProjectFiles` and added them back in. 