### PR TITLE
Do not restart if C# server exits

### DIFF
--- a/src/languageServerClient.ts
+++ b/src/languageServerClient.ts
@@ -128,7 +128,7 @@ export class StripeLanguageClient {
 
           return ErrorAction.Continue;
         },
-        closed: () => CloseAction.Restart,
+        closed: () => CloseAction.DoNotRestart,
       },
     };
 


### PR DESCRIPTION
If the C# server fails to start up for an unrecoverable reason, restarting it will cause repeated crashes:

https://github.com/stripe/vscode-stripe/issues/292

This does not address the original root cause of the crash, but will mitigate the repeated crashes users will experience on mac. 