### PR TITLE
Resolving samples information box

### DIFF
--- a/test/suite/stripeSamples.test.ts
+++ b/test/suite/stripeSamples.test.ts
@@ -85,8 +85,9 @@ suite('StripeSamples', function () {
         const showOpenDialogStub = sandbox
           .stub(vscode.window, 'showOpenDialog')
           .resolves([vscode.Uri.parse('/my/path')]);
-        const showInformationMessageSpy = sandbox.spy(vscode.window, 'showInformationMessage');
-
+        const showInformationMessageStub = sandbox
+          .stub(vscode.window, 'showInformationMessage')
+          .resolves();
         const stripeSamples = new StripeSamples(<any>stripeClient, <any>stripeDaemon);
 
         stripeSamples.selectAndCloneSample();
@@ -95,7 +96,7 @@ suite('StripeSamples', function () {
 
         assert.strictEqual(showQuickPickSpy.callCount, 4);
         assert.strictEqual(showOpenDialogStub.callCount, 1);
-        assert.strictEqual(showInformationMessageSpy.callCount, 1);
+        assert.strictEqual(showInformationMessageStub.callCount, 1);
       });
 
       test('shows special post install message if API keys could not be set', async () => {
@@ -118,8 +119,9 @@ suite('StripeSamples', function () {
 
         sandbox.stub(stripeDaemon, 'setupClient').resolves(daemonClient);
         sandbox.stub(vscode.window, 'showOpenDialog').resolves([vscode.Uri.parse('/my/path')]);
-        const showInformationMessageSpy = sandbox.spy(vscode.window, 'showInformationMessage');
-
+        const showInformationMessageStub = sandbox
+          .stub(vscode.window, 'showInformationMessage')
+          .resolves();
         const stripeSamples = new StripeSamples(<any>stripeClient, <any>stripeDaemon);
 
         stripeSamples.selectAndCloneSample();
@@ -127,7 +129,7 @@ suite('StripeSamples', function () {
         await simulateSelectAll();
 
         assert.deepStrictEqual(
-          showInformationMessageSpy.args[0][0],
+          showInformationMessageStub.args[0][0],
           'The sample was successfully created, but we could not set the API keys in the .env file. Please set them manually.',
         );
       });


### PR DESCRIPTION
A test recently began to fail in some platforms intermittently after 1.58.1. Upon [investigation with logs](https://github.com/stripe/vscode-stripe/actions/runs/1028044302), the failing test was never getting the quick pick item selections. Running the failing test by itself would [pass](https://github.com/stripe/vscode-stripe/actions/runs/1028125520). 

My guess is that something changed with the showInformation window that will cause it to hang if we don't pick a prompted selection. I made the window return quickly with a selected value which then allowed the subsequent test to run as it did before.
