### PR TITLE
stubbing out osName() in commands test

### DIFF
--- a/test/suite/commands.test.ts
+++ b/test/suite/commands.test.ts
@@ -11,6 +11,10 @@ import {SurveyPrompt} from '../../src/surveyPrompt';
 import childProcess from 'child_process';
 import {mocks} from '../mocks/vscode';
 
+const proxyquire = require('proxyquire');
+const modulePath = '../../src/commands';
+const setupProxies = (proxies: any) => proxyquire(modulePath, proxies);
+
 suite('commands', function () {
   this.timeout(20000);
 
@@ -124,10 +128,13 @@ suite('commands', function () {
   suite('openSurvey', () => {
     test('openSurvey saves survey prompt settings', () => {
       sandbox.stub(vscode.env, 'openExternal');
+      // stub out osName
+      const osName = sandbox.stub().returns('testOS');
+      const module = setupProxies({'os-name': osName});
 
       const surveyPrompt = new SurveyPrompt(extensionContext);
       const promptSpy = sandbox.spy(surveyPrompt, 'updateSurveySettings');
-      const commands = new Commands(telemetry, terminal, extensionContext);
+      const commands = new module.Commands(telemetry, terminal, extensionContext);
       commands.openSurvey(surveyPrompt);
 
       assert.strictEqual(promptSpy.calledOnce, true);


### PR DESCRIPTION
The openSurvey test began to fail recently for windows. Inspection with the timer shows that the osName() function was taking much longer on the windows machine. On mac and linux it is on the order of single digit milliseconds and for windows it can span many seconds. This commit fixes the testing timeout issue by mocking out this call.

I am still concerned that the call actually takes that long on windows machines and how that's impacting latency, especially since we use this constantly for telemetry. I'll continue investigating this. 


Before: https://github.com/stripe/vscode-stripe/runs/3089718394?check_suite_focus=true
```
Telemetry: 0
getExtensionInfo: 0
get OSName: 21943
encode platform: 0
encode version: 0
encode version: 0
encode version: 0
form query string: 0
open link: 0
update setting: 0
Survey command: 21944
```

After: https://github.com/stripe/vscode-stripe/runs/3090106534?check_suite_focus=true
```
Test setup: 13	
Telemetry: 0
getExtensionInfo: 1
OStestOS
get OSName: 0
encode platform: 0
encode version: 0
encode version: 0
encode version: 0
form query string: 1
open link: 0
update setting: 1
Survey command: 5
```