### PR TITLE
Dynamically retrieve supported triggers list from CLI

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -19,7 +19,7 @@ import {StripeTerminal} from './stripeTerminal';
 import {StripeTreeItem} from './stripeTreeItem';
 import {SurveyPrompt} from './surveyPrompt';
 import {Telemetry} from './telemetry';
-import {TriggersListRequest, TriggersListResponse} from './rpc/triggers_list_pb';
+import {TriggersListRequest} from './rpc/triggers_list_pb';
 
 export class Commands {
   telemetry: Telemetry;

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -11,6 +11,7 @@ import {
 } from './stripeWorkspaceState';
 import {getExtensionInfo, showQuickPickWithItems} from './utils';
 import osName = require('os-name');
+import {StripeDaemon} from './daemon/stripeDaemon';
 import {StripeEventsViewProvider} from './stripeEventsView';
 import {StripeLogsViewProvider} from './stripeLogsView';
 import {StripeSamples} from './stripeSamples';
@@ -18,6 +19,7 @@ import {StripeTerminal} from './stripeTerminal';
 import {StripeTreeItem} from './stripeTreeItem';
 import {SurveyPrompt} from './surveyPrompt';
 import {Telemetry} from './telemetry';
+import {TriggersListRequest, TriggersListResponse} from './rpc/triggers_list_pb';
 
 export class Commands {
   telemetry: Telemetry;
@@ -285,10 +287,24 @@ export class Commands {
   openTriggerEvent = async (
     extensionContext: vscode.ExtensionContext,
     stripeClient: StripeClient,
+    stripeDaemon: StripeDaemon,
     stripeOutputChannel: vscode.OutputChannel,
   ) => {
     this.telemetry.sendEvent('openTriggerEvent');
-    const events = this.buildTriggerEventsList(this.supportedEvents, extensionContext);
+    const daemonClient = await stripeDaemon.setupClient();
+
+    const supportedTriggersList = await new Promise<string[]>((resolve, reject) => {
+      daemonClient.triggersList(new TriggersListRequest(), (error, response) => {
+        if (error) {
+          stripeOutputChannel.append('Warning: Failed to retrieve supported triggered event list dynamically: ' + error + '\n');
+          resolve(this.supportedEvents);
+        } else if (response) {
+          resolve(response.getEventsList());
+        }
+      });
+    });
+
+    const events = this.buildTriggerEventsList(supportedTriggersList, extensionContext);
     const eventName = await showQuickPickWithItems('Enter event name to trigger', events);
     if (eventName) {
       const triggerProcess = await stripeClient.getOrCreateCLIProcess(CLICommand.Trigger, [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -146,7 +146,7 @@ export function activate(this: any, context: ExtensionContext) {
     ['stripe.openTelemetryInfo', stripeCommands.openTelemetryInfo],
     [
       'stripe.openTriggerEvent',
-      () => stripeCommands.openTriggerEvent(context, stripeClient, stripeOutputChannel),
+      () => stripeCommands.openTriggerEvent(context, stripeClient, stripeDaemon, stripeOutputChannel),
     ],
     ['stripe.openWebhooksDebugConfigure', stripeCommands.openWebhooksDebugConfigure],
     ['stripe.openWebhooksListen', stripeCommands.openWebhooksListen],

--- a/test/suite/commands.test.ts
+++ b/test/suite/commands.test.ts
@@ -7,6 +7,7 @@ import {EventEmitter, Readable} from 'stream';
 import {Commands} from '../../src/commands';
 import {NoOpTelemetry} from '../../src/telemetry';
 import {StripeClient} from '../../src/stripeClient';
+import {StripeDaemon} from '../daemon/stripeDaemon';
 import {SurveyPrompt} from '../../src/surveyPrompt';
 import childProcess from 'child_process';
 import {mocks} from '../mocks/vscode';
@@ -40,6 +41,7 @@ suite('commands', function () {
     let stripeOutputChannel: Partial<vscode.OutputChannel>;
     let triggerProcess: childProcess.ChildProcess;
     let stripeClient: Partial<StripeClient>;
+    let stripeDaemon: Partial<StripeDaemon>;
 
     setup(() => {
       stripeOutputChannel = {append: (value: string) => {}, show: () => {}};
@@ -56,7 +58,7 @@ suite('commands', function () {
       const supportedEvents = ['a'];
       const commands = new Commands(telemetry, terminal, extensionContext, supportedEvents);
 
-      commands.openTriggerEvent(extensionContext, <any>stripeClient, <any>stripeOutputChannel);
+      commands.openTriggerEvent(extensionContext, <any>stripeClient, <any>stripeDaemon, <any>stripeOutputChannel);
 
       // Pick the first item on the list.
       await vscode.commands.executeCommand('workbench.action.acceptSelectedQuickOpenItem');
@@ -73,7 +75,7 @@ suite('commands', function () {
       const supportedEvents = ['a'];
       const commands = new Commands(telemetry, terminal, extensionContext, supportedEvents);
 
-      commands.openTriggerEvent(extensionContext, <any>stripeClient, <any>stripeOutputChannel);
+      commands.openTriggerEvent(extensionContext, <any>stripeClient, <any>stripeDaemon, <any>stripeOutputChannel);
 
       // Pick the first item on the list.
       await vscode.commands.executeCommand('workbench.action.acceptSelectedQuickOpenItem');

--- a/test/suite/commands.test.ts
+++ b/test/suite/commands.test.ts
@@ -1,11 +1,14 @@
 import * as assert from 'assert';
+import * as grpc from '@grpc/grpc-js';
 import * as sinon from 'sinon';
 import * as stripeState from '../../src/stripeWorkspaceState';
 import * as vscode from 'vscode';
 
 import {EventEmitter, Readable} from 'stream';
+import {TriggersListRequest, TriggersListResponse} from '../../src/rpc/triggers_list_pb';
 import {Commands} from '../../src/commands';
 import {NoOpTelemetry} from '../../src/telemetry';
+import {StripeCLIClient} from '../../src/rpc/commands_grpc_pb';
 import {StripeClient} from '../../src/stripeClient';
 import {StripeDaemon} from '../daemon/stripeDaemon';
 import {SurveyPrompt} from '../../src/surveyPrompt';
@@ -28,6 +31,20 @@ suite('commands', function () {
 
   const telemetry = new NoOpTelemetry();
 
+  const stripeDaemon = <Partial<StripeDaemon>>{
+      setupClient: () => {},
+    };
+
+  const supportedEvents = ['a'];
+  const daemonClient = <Partial<StripeCLIClient>>{
+      triggersList: (
+        req: TriggersListRequest,
+        callback: (error: grpc.ServiceError | null, res: TriggersListResponse) => void,
+    ) => {
+      callback(null, new TriggersListResponse());
+    },
+  };
+
   setup(() => {
     sandbox = sinon.createSandbox();
     extensionContext = {...mocks.extensionContextMock};
@@ -41,23 +58,33 @@ suite('commands', function () {
     let stripeOutputChannel: Partial<vscode.OutputChannel>;
     let triggerProcess: childProcess.ChildProcess;
     let stripeClient: Partial<StripeClient>;
-    let stripeDaemon: Partial<StripeDaemon>;
 
     setup(() => {
+      sandbox.stub(stripeDaemon, 'setupClient').resolves(daemonClient);
       stripeOutputChannel = {append: (value: string) => {}, show: () => {}};
 
       triggerProcess = <childProcess.ChildProcess>new EventEmitter();
       triggerProcess.stdout = <Readable>new EventEmitter();
-
       stripeClient = {getOrCreateCLIProcess: () => Promise.resolve(triggerProcess)};
     });
 
     test('executes and records event', async () => {
       const telemetrySpy = sandbox.spy(telemetry, 'sendEvent');
+      const mockResp = new TriggersListResponse();
+      mockResp.setEventsList(supportedEvents);
 
-      const supportedEvents = ['a'];
-      const commands = new Commands(telemetry, terminal, extensionContext, supportedEvents);
+      sandbox
+        .stub(daemonClient, 'triggersList')
+        .value(
+          (
+            req: TriggersListRequest,
+            callback: (error: grpc.ServiceError | null, res: TriggersListResponse) => void,
+          ) => {
+            callback(null, mockResp);
+          },
+        );
 
+      const commands = new Commands(telemetry, terminal, extensionContext);
       commands.openTriggerEvent(extensionContext, <any>stripeClient, <any>stripeDaemon, <any>stripeOutputChannel);
 
       // Pick the first item on the list.
@@ -66,15 +93,58 @@ suite('commands', function () {
       const eventsInState = stripeState.getRecentEvents(extensionContext);
 
       assert.deepStrictEqual(telemetrySpy.args[0], ['openTriggerEvent']);
-      assert.deepStrictEqual(eventsInState, ['a']);
+      assert.deepStrictEqual(eventsInState, supportedEvents);
     });
+
+    test('uses fallback events list if fails to retrieve list through grpc', async () => {
+      const telemetrySpy = sandbox.spy(telemetry, 'sendEvent');
+      const err: Partial<grpc.ServiceError> = {
+          code: grpc.status.UNKNOWN,
+          details: 'An unknown error occurred',
+        };
+
+      sandbox
+        .stub(daemonClient, 'triggersList')
+        .value(
+          (
+            req: TriggersListRequest,
+            callback: (error: grpc.ServiceError | null, res: TriggersListResponse) => void,
+          ) => {
+            callback(<any>err, new TriggersListResponse());
+          },
+        );
+
+      const fallbackEventsList = ['fall', 'back', 'list'];
+      const commands = new Commands(telemetry, terminal, extensionContext, fallbackEventsList);
+      commands.openTriggerEvent(extensionContext, <any>stripeClient, <any>stripeDaemon, <any>stripeOutputChannel);
+
+      // Pick the first item on the list.
+      await vscode.commands.executeCommand('workbench.action.acceptSelectedQuickOpenItem');
+
+      const eventsInState = stripeState.getRecentEvents(extensionContext);
+
+      assert.deepStrictEqual(telemetrySpy.args[0], ['openTriggerEvent']);
+      assert.deepStrictEqual(eventsInState[0], 'fall');
+    });
+
 
     test('writes stripe trigger output to output channel', async () => {
       const appendSpy = sinon.spy(stripeOutputChannel, 'append');
+      const mockResp = new TriggersListResponse();
+      mockResp.setEventsList(supportedEvents);
 
-      const supportedEvents = ['a'];
-      const commands = new Commands(telemetry, terminal, extensionContext, supportedEvents);
+      sandbox
+        .stub(daemonClient, 'triggersList')
+        .value(
+          (
+            req: TriggersListRequest,
+            callback: (error: grpc.ServiceError | null, res: TriggersListResponse) => void,
+          ) => {
+            callback(null, mockResp);
+          },
+        );
 
+      const commands = new Commands(telemetry, terminal, extensionContext);
       commands.openTriggerEvent(extensionContext, <any>stripeClient, <any>stripeDaemon, <any>stripeOutputChannel);
 
       // Pick the first item on the list.


### PR DESCRIPTION
## Summary
context: https://github.com/stripe/vscode-stripe/issues/217

Supported list of events was a static list in our extension:
`vscode-stripe/src/commands.ts`
```
 supportedEvents: string[] = [ 
We need a better way to keep this in sync. Couple of options:
```

To dynamically retrieve the supported triggered events list, make a call to the CLI gPRC service at trigger event click. if the list is failed to be retrieved, then fall back to the old static list and outputs an warning to output window

![Screen Shot 2021-09-14 at 1 57 24 PM](https://user-images.githubusercontent.com/88805634/133334902-af6d705c-fac4-4259-a68f-2b14cc4f4a54.png)
![Screen Shot 2021-09-14 at 11 44 38 AM](https://user-images.githubusercontent.com/88805634/133334905-e1240960-a484-4736-a3ba-caf645a122e4.png)
