### PR TITLE
Starting stripe daemon with custom user agent

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,7 @@
 import * as vscode from 'vscode';
 
+const extensionId = 'stripe.vscode-stripe';
+
 export enum OSType {
   macOSintel = 'macOSintel',
   macOSarm = 'macOSarm',
@@ -8,8 +10,15 @@ export enum OSType {
   windows = 'windows',
 }
 
+export function getUserAgent() {
+  const extension = vscode.extensions.getExtension(extensionId);
+  return extension
+    ? `${extension.id}/${extension.packageJSON?.version} vscode/${vscode.version}`
+    : '';
+}
+
 export function getExtensionInfo() {
-  const extension = vscode.extensions.getExtension('stripe.vscode-stripe');
+  const extension = vscode.extensions.getExtension(extensionId);
   if (extension) {
     return extension.packageJSON;
   }

--- a/test/suite/stripeDaemon.test.ts
+++ b/test/suite/stripeDaemon.test.ts
@@ -65,7 +65,7 @@ suite('StripeDaemon', () => {
       assert.strictEqual(constructorStub.args[0][0], '[::1]:12345');
     });
 
-    test('sends coorrect channel options', async () => {
+    test('sends correct channel options', async () => {
       const stripeDaemon = getStripeDaemonWithExecaProxy(
         '{"host": "::1", "port": 12345}',
         <any>stripeClient,
@@ -85,7 +85,8 @@ suite('StripeDaemon', () => {
 
       const userAgent =
         constructorStub.args[0][2].channelOverride.options['grpc.primary_user_agent'];
-      console.log(userAgent);
+
+      // Note I could not mock out the module that's used within the utils class so we are just asserting for a startsWith
       assert.strictEqual(userAgent.startsWith('my-extension/1 vscode/'), true);
     });
 

--- a/test/suite/utils.test.ts
+++ b/test/suite/utils.test.ts
@@ -2,6 +2,10 @@ import * as assert from 'assert';
 import * as sinon from 'sinon';
 import * as utils from '../../src/utils';
 import * as vscode from 'vscode';
+const proxyquire = require('proxyquire');
+const modulePath = '../../src/utils';
+
+const setupProxies = (proxies: any) => proxyquire(modulePath, proxies);
 
 suite('Utils', () => {
   let sandbox: sinon.SinonSandbox;
@@ -12,6 +16,56 @@ suite('Utils', () => {
 
   teardown(() => {
     sandbox.restore();
+  });
+
+  suite('getUserAgent', () => {
+    let module: {getUserAgent: () => any};
+
+    setup(() => {
+      module = setupProxies({
+        vscode: {
+          version: 2,
+        },
+      });
+    });
+
+    test('getUserAgent returns user agent', () => {
+      const mockExtension = <vscode.Extension<any>>{
+        id: 'my-extension',
+        packageJSON: {version: 1},
+      };
+      sandbox.stub(vscode.extensions, 'getExtension').returns(mockExtension);
+      const userAgent = module.getUserAgent();
+      assert.strictEqual(userAgent, 'my-extension/1 vscode/2');
+    });
+
+    test('getUserAgent returns blank when getExtension returns nothing', () => {
+      sandbox.stub(vscode.extensions, 'getExtension').returns(undefined);
+      const userAgent = module.getUserAgent();
+      console.log(userAgent);
+      assert.strictEqual(userAgent, '');
+    });
+
+    test('getUserAgent does not error when packgeJSON does not exist', () => {
+      const mockExtension = <vscode.Extension<any>>{
+        id: 'my-extension',
+      };
+      sandbox.stub(vscode.extensions, 'getExtension').returns(mockExtension);
+      const userAgent = module.getUserAgent();
+      console.log(userAgent);
+      assert.strictEqual(userAgent, 'my-extension/undefined vscode/2');
+    });
+
+    test('getUserAgent does not error when packgeJSON does not contain version', () => {
+      const mockExtension = <vscode.Extension<any>>{
+        id: 'my-extension',
+        packageJSON: {},
+      };
+      sandbox.stub(vscode.extensions, 'getExtension').returns(mockExtension);
+      const userAgent = module.getUserAgent();
+      console.log(userAgent);
+      assert.strictEqual(userAgent, 'my-extension/undefined vscode/2');
+    });
   });
 
   suite('showQuickPick', () => {

--- a/test/suite/utils.test.ts
+++ b/test/suite/utils.test.ts
@@ -42,7 +42,6 @@ suite('Utils', () => {
     test('getUserAgent returns blank when getExtension returns nothing', () => {
       sandbox.stub(vscode.extensions, 'getExtension').returns(undefined);
       const userAgent = module.getUserAgent();
-      console.log(userAgent);
       assert.strictEqual(userAgent, '');
     });
 
@@ -52,7 +51,6 @@ suite('Utils', () => {
       };
       sandbox.stub(vscode.extensions, 'getExtension').returns(mockExtension);
       const userAgent = module.getUserAgent();
-      console.log(userAgent);
       assert.strictEqual(userAgent, 'my-extension/undefined vscode/2');
     });
 
@@ -63,7 +61,6 @@ suite('Utils', () => {
       };
       sandbox.stub(vscode.extensions, 'getExtension').returns(mockExtension);
       const userAgent = module.getUserAgent();
-      console.log(userAgent);
       assert.strictEqual(userAgent, 'my-extension/undefined vscode/2');
     });
   });


### PR DESCRIPTION
This allows us to see this value in our stripe cli telemetry. 

## Testing
With custom logging from the Stripe CLI, this is what the gRPC service sees:
```
User agent: stripe.vscode-stripe/2.0.4 vscode/1.59.0-insider grpc-node-js/1.3.7
```
