### PR TITLE
Updating trigger events to use gRPC method

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -146,7 +146,7 @@ export function activate(this: any, context: ExtensionContext) {
     ['stripe.openTelemetryInfo', stripeCommands.openTelemetryInfo],
     [
       'stripe.openTriggerEvent',
-      () => stripeCommands.openTriggerEvent(context, stripeClient, stripeDaemon, stripeOutputChannel),
+      () => stripeCommands.openTriggerEvent(context, stripeDaemon, stripeOutputChannel),
     ],
     ['stripe.openWebhooksDebugConfigure', stripeCommands.openWebhooksDebugConfigure],
     ['stripe.openWebhooksListen', stripeCommands.openWebhooksListen],

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -66,6 +66,7 @@ export function showQuickPickWithItems(
     input.onDidAccept(() => {
       const value = input.selectedItems[0].label;
       resolve(value);
+      input.hide();
     });
 
     input.show();


### PR DESCRIPTION
## Summary 
The open trigger event used to kick off the trigger via a command line process. This change updates this logic to use the gRPC method which has a more concrete contract. 


## Testing
Before this change:
https://d37ugbyn3rpeym.cloudfront.net/videos/developers/stripe_vs_code/forward-webhooks-demo_2.0.0.mp4

After this change:
https://user-images.githubusercontent.com/75757829/138504870-508de5ba-2968-4cc3-b59a-88634dee214b.mp4


