### PR TITLE
DX6964: store java home path in user settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,10 @@
           "default": true,
           "markdownDescription": "Specifies whether to enable Stripe telemetry (even if enabled still abides by the overall `#telemetry.enableTelemetry#` setting)",
           "scope": "window"
+        },
+        "stripe.java.home": {
+          "type": "string", 
+          "description": "Java home path of the JDK for Java language support"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -92,7 +92,8 @@
         },
         "stripe.java.home": {
           "type": "string", 
-          "description": "Java home path of the JDK for Java language support"
+          "description": "Java home path of the JDK for Java language support",
+          "scope": "machine"
         }
       }
     },

--- a/src/languageServerClient.ts
+++ b/src/languageServerClient.ts
@@ -6,6 +6,7 @@ import {
   ACTIVE_BUILD_TOOL_STATE,
   ClientStatus,
   JDKInfo,
+  STRIPE_JAVA_HOME,
   ServerMode,
   getJavaFilePathOfTextDocument,
   getJavaSDKInfo,
@@ -69,7 +70,7 @@ export class StripeLanguageClient {
       const jdkInfo = await getJavaSDKInfo(context, outputChannel);
       if (jdkInfo.javaVersion < REQUIRED_JDK_VERSION) {
         outputChannel.appendLine(
-          `Minimum JDK version required is ${REQUIRED_JDK_VERSION}. Please update the java.home setup in VSCode user settings.`,
+          `Minimum JDK version required for Java API Reference at code hover is ${REQUIRED_JDK_VERSION}. Please update the ${STRIPE_JAVA_HOME} variable in user settings.`,
         );
         telemetry.sendEvent('doesNotMeetRequiredJdkVersion');
         return;

--- a/src/stripeJavaLanguageClient/utils.ts
+++ b/src/stripeJavaLanguageClient/utils.ts
@@ -347,7 +347,7 @@ export async function getJavaSDKInfo(
     sdkInfo = {javaHome, javaVersion};
   } else {
     // java.home not defined, search valid JDKs from env.JAVA_HOME, env.PATH, Registry(Window), Common directories
-    sdkInfo = await getJavaHomeFromEnvironment();
+    sdkInfo = getJavaHomeFromEnvironment();
   }
 
   // update vscode java.home workspace value for fast access next time
@@ -356,15 +356,15 @@ export async function getJavaSDKInfo(
   return sdkInfo;
 }
 
-async function getJavaHomeFromConfig() {
+function getJavaHomeFromConfig() {
   const inspect = workspace.getConfiguration().inspect<string>(STRIPE_JAVA_HOME);
   // workspace value takes precedence over global value
   const javaHome = inspect?.workspaceValue || inspect?.globalValue || '';
   return javaHome;
 }
 
-async function getJavaHomeFromEnvironment(): Promise<JDKInfo> {
-  // TODO: DX6965
+function getJavaHomeFromEnvironment(): JDKInfo {
+  // TO-DO: DX6965
   return {javaHome: '', javaVersion: 0};
 }
 
@@ -401,7 +401,7 @@ async function updateJavaHomeWorkspaceConfig(context: ExtensionContext, javaHome
     });
   } else if (allowWorkspaceEdit) {
     const inspect = workspace.getConfiguration().inspect<string>(STRIPE_JAVA_HOME);
-    if (inspect?.workspaceValue != javaHome) {
+    if (inspect?.workspaceValue !== javaHome) {
       await workspace.getConfiguration().update(STRIPE_JAVA_HOME, javaHome, ConfigurationTarget.Workspace);
     }
   }

--- a/src/stripeJavaLanguageClient/utils.ts
+++ b/src/stripeJavaLanguageClient/utils.ts
@@ -34,6 +34,7 @@ export const DEBUG_VSCODE_JAVA = 'DEBUG_VSCODE_JAVA';
 export const EXTENSION_NAME_STANDARD = 'stripeJavaLanguageServer (Standard)';
 export const EXTENSION_NAME_SYNTAX = 'stripeJavaLanguageServer (Syntax)';
 export const IS_WORKSPACE_JDK_ALLOWED = 'java.ls.isJdkAllowed';
+export const STRIPE_JAVA_HOME = 'stripe.java.home';
 
 export interface JDKInfo {
   javaHome: string;
@@ -322,9 +323,12 @@ export async function getJavaSDKInfo(
 ): Promise<JDKInfo> {
   let source: string;
   let javaVersion: number = 0;
-  let javaHome = (await checkJavaPreferences(context)) || '';
+  // get java.home from vscode settings config first
+  let javaHome = await getJavaHomeFromConfig() || '';
+  let sdkInfo = {javaVersion, javaHome};
+
   if (javaHome) {
-    source = `java.home variable defined in ${env.appName} settings`;
+    source = `${STRIPE_JAVA_HOME} variable defined in ${env.appName} settings`;
     javaHome = expandHomeDir(javaHome);
     if (!(await fse.pathExists(javaHome))) {
       outputChannel.appendLine(
@@ -340,50 +344,67 @@ export async function getJavaSDKInfo(
       outputChannel.appendLine(msg);
     }
     javaVersion = (await getJavaVersion(javaHome)) || 0;
+    sdkInfo = {javaHome, javaVersion};
+  } else {
+    // java.home not defined, search valid JDKs from env.JAVA_HOME, env.PATH, Registry(Window), Common directories
+    sdkInfo = await getJavaHomeFromEnvironment();
   }
-  return {javaHome, javaVersion};
+
+  // update vscode java.home workspace value for fast access next time
+  updateJavaHomeWorkspaceConfig(context, sdkInfo.javaHome);
+
+  return sdkInfo;
 }
 
-async function checkJavaPreferences(context: ExtensionContext) {
+async function getJavaHomeFromConfig() {
+  const inspect = workspace.getConfiguration().inspect<string>(STRIPE_JAVA_HOME);
+  // workspace value takes precedence over global value
+  const javaHome = inspect?.workspaceValue || inspect?.globalValue || '';
+  return javaHome;
+}
+
+async function getJavaHomeFromEnvironment(): Promise<JDKInfo> {
+  // TODO: DX6965
+  return {javaHome: '', javaVersion: 0};
+}
+
+async function updateJavaHomeWorkspaceConfig(context: ExtensionContext, javaHome: string) {
+  if (!javaHome) {
+    return;
+  }
+
   const allow = 'Allow';
   const disallow = 'Disallow';
-  let inspect = workspace.getConfiguration().inspect<string>('java.home');
-  let javaHome = inspect && inspect.workspaceValue;
-  let isVerified = javaHome === undefined || javaHome === null;
-  if (isVerified) {
-    javaHome = getJavaConfiguration().get('home');
-  }
+
   const key = getKey(IS_WORKSPACE_JDK_ALLOWED, context.storagePath, javaHome);
   const globalState = context.globalState;
-  if (!isVerified) {
-    isVerified = globalState.get(key) || false;
-    if (isVerified === undefined) {
-      await window
-        .showErrorMessage(
-          `Do you allow this workspace to set the java.home variable? \n java.home: ${javaHome}`,
-          disallow,
-          allow,
-        )
-        .then(async (selection) => {
-          if (selection === allow) {
-            globalState.update(key, true);
-          } else if (selection === disallow) {
-            globalState.update(key, false);
-            await workspace
-              .getConfiguration()
-              .update('java.home', undefined, ConfigurationTarget.Workspace);
-          }
-        });
-      isVerified = globalState.get(key) || false;
+  const allowWorkspaceEdit = globalState.get(key);
+
+  if (allowWorkspaceEdit === undefined) {
+    await window.showErrorMessage(
+      `Do you allow this workspace to set the ${STRIPE_JAVA_HOME} variable? \n ${STRIPE_JAVA_HOME}: ${javaHome}`,
+      disallow,
+      allow,
+    )
+    .then(async (selection) => {
+      if (selection === allow) {
+        globalState.update(key, true);
+        await workspace
+          .getConfiguration()
+          .update(STRIPE_JAVA_HOME, javaHome, ConfigurationTarget.Workspace);
+      } else if (selection === disallow) {
+        globalState.update(key, false);
+        await workspace
+          .getConfiguration()
+          .update(STRIPE_JAVA_HOME, undefined, ConfigurationTarget.Workspace);
+      }
+    });
+  } else if (allowWorkspaceEdit) {
+    const inspect = workspace.getConfiguration().inspect<string>(STRIPE_JAVA_HOME);
+    if (inspect?.workspaceValue != javaHome) {
+      await workspace.getConfiguration().update(STRIPE_JAVA_HOME, javaHome, ConfigurationTarget.Workspace);
     }
   }
-
-  if (!isVerified) {
-    inspect = workspace.getConfiguration().inspect<string>('java.home');
-    javaHome = inspect && inspect.globalValue;
-  }
-
-  return javaHome;
 }
 
 async function getJavaVersion(javaHome: string): Promise<number | undefined> {


### PR DESCRIPTION
https://jira.corp.stripe.com/browse/DX-6964

better user experience when JDK version is missing

### updated warning message
![Screen Shot 2021-11-08 at 4 51 57 PM](https://user-images.githubusercontent.com/88805634/140841621-97b8f5ad-2552-4829-b57c-932f16508dfd.png)

### stripe.java.home settings for easier jdk setup
![Screen Shot 2021-11-08 at 4 38 55 PM](https://user-images.githubusercontent.com/88805634/140841317-15fbe974-763c-4480-aa3f-e4888297756d.png)

### prompt user to set jdk path in user settings
![Screen Shot 2021-11-08 at 11 45 08 AM](https://user-images.githubusercontent.com/88805634/140841319-acb5c239-3761-4471-b5a2-24c6972f9a8e.png)


