### PR TITLE
Increasing timeouts for linter tests

### DIFF
--- a/test/suite/stripeLinter.test.ts
+++ b/test/suite/stripeLinter.test.ts
@@ -5,7 +5,9 @@ import {Git} from '../../src/git';
 import {NoOpTelemetry} from '../../src/telemetry';
 import {StripeLinter} from '../../src/stripeLinter';
 
-suite('StripeLinter', () => {
+suite('StripeLinter', function () {
+  this.timeout(20000);
+
   let sandbox: sinon.SinonSandbox;
   const telemetry = new NoOpTelemetry();
   const git = new Git();
@@ -71,7 +73,10 @@ suite('StripeLinter', () => {
       const diagnostics: vscode.Diagnostic[] = vscode.languages.getDiagnostics(document.uri);
 
       assert.strictEqual(isIgnoredStub.calledOnce, true);
-      assert.strictEqual(telemetrySpy.calledWith('diagnostics.show', vscode.DiagnosticSeverity.Error), true);
+      assert.strictEqual(
+        telemetrySpy.calledWith('diagnostics.show', vscode.DiagnosticSeverity.Error),
+        true,
+      );
       assert.strictEqual(diagnostics.length, 1);
     });
 


### PR DESCRIPTION
r? @etsai-stripe 

These tests have been intermittently failing due to timeouts: https://github.com/stripe/vscode-stripe/runs/4121204401?check_suite_focus=true

The open and show document functions can take a couple of seconds in the worst case scenario which will cause the test to timeout (the default is 2 seconds). Even for ones that do pass, we always come close to the timeout in the first two test cases.

See logs added here: https://github.com/stripe/vscode-stripe/runs/4159081815?check_suite_focus=true. 
```
Doc open took: 245 ms
Doc show took: 126 ms
Test set up took 374 ms
Linter construction took 1 ms
File is ignored by git? true
Linter.activate took  2 ms
Test cleanup  1 ms
      ✔ Editor content is not searched when file is git-ignored (379ms)
```