### PR TITLE
vscode release v2.0.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-stripe",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-stripe",
   "displayName": "Stripe",
   "description": "Build, test, and use Stripe inside your editor.",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "publisher": "stripe",
   "author": "Stripe (https://www.stripe.com)",
   "license": "SEE LICENSE IN LICENSE.md",
@@ -15,7 +15,7 @@
     "url": "https://github.com/stripe/vscode-stripe/issues"
   },
   "engines": {
-    "vscode": "^1.61.0"
+    "vscode": "^1.62.0"
   },
   "icon": "resources/logo.png",
   "categories": [


### PR DESCRIPTION
tested by installing the v2.0.10 .vsix file

## v2.0.10 installed for manual testing
![Screen Shot 2021-11-16 at 11 34 54 AM](https://user-images.githubusercontent.com/88805634/142053638-cff649d5-46a8-4990-ab29-3b5addefb177.png)

## Extension Pack for Java not installed with stripe extension
addressing issue https://github.com/stripe/vscode-stripe/issues/439
![Screen Shot 2021-11-16 at 11 33 18 AM](https://user-images.githubusercontent.com/88805634/142053597-ea7ad541-651e-49d5-b4ee-50e8d387d468.png)

## new user settings for java project detection
![Screen Shot 2021-11-16 at 11 32 43 AM](https://user-images.githubusercontent.com/88805634/142053567-178144c7-e86c-49fc-a9c6-17c24aa662ba.png)

## java lang support working in v2.0.10
![Screen Shot 2021-11-16 at 11 32 57 AM](https://user-images.githubusercontent.com/88805634/142053578-b04a9f2c-f4dd-45c6-909a-538242d220a9.png)





