### PR TITLE
dx-6943: allow user defined sample name

### DIFF
--- a/test/suite/stripeSamples.test.ts
+++ b/test/suite/stripeSamples.test.ts
@@ -82,6 +82,9 @@ suite('StripeSamples', function () {
       test('prompts for sample config, clones, and opens sample', async () => {
         sandbox.stub(stripeDaemon, 'setupClient').resolves(daemonClient);
         const showQuickPickSpy = sandbox.spy(vscode.window, 'showQuickPick');
+        const showInputBoxStub = sandbox
+          .stub(vscode.window, 'showInputBox')
+          .resolves('sample-name-by-user');
         const showOpenDialogStub = sandbox
           .stub(vscode.window, 'showOpenDialog')
           .resolves([vscode.Uri.parse('/my/path')]);
@@ -95,6 +98,7 @@ suite('StripeSamples', function () {
         await simulateSelectAll();
 
         assert.strictEqual(showQuickPickSpy.callCount, 4);
+        assert.strictEqual(showInputBoxStub.callCount, 1);
         assert.strictEqual(showOpenDialogStub.callCount, 1);
         assert.strictEqual(showInformationMessageStub.callCount, 1);
       });
@@ -118,6 +122,7 @@ suite('StripeSamples', function () {
           );
 
         sandbox.stub(stripeDaemon, 'setupClient').resolves(daemonClient);
+        sandbox.stub(vscode.window, 'showInputBox').resolves('sample-name-by-user');
         sandbox.stub(vscode.window, 'showOpenDialog').resolves([vscode.Uri.parse('/my/path')]);
         const showInformationMessageStub = sandbox
           .stub(vscode.window, 'showInformationMessage')
@@ -130,7 +135,7 @@ suite('StripeSamples', function () {
 
         assert.deepStrictEqual(
           showInformationMessageStub.args[0][0],
-          'Your sample is all ready to go, but we could not set the API keys in the .env file. Please set them manually.',
+          'Your sample "sample-name-by-user" is all ready to go, but we could not set the API keys in the .env file. Please set them manually.',
         );
       });
     });


### PR DESCRIPTION
https://jira.corp.stripe.com/browse/DX-6943

allow user to define the name to download the sample as. use original sample name by default.

## prompt user for name. default is sample name
![Screen Shot 2021-11-17 at 9 41 59 AM](https://user-images.githubusercontent.com/88805634/142255557-c20fc7dc-afbc-4dc9-9ba5-273aa30c9d54.png)

## select folder to clone. folder already has sample with the default name
![Screen Shot 2021-11-17 at 9 42 24 AM](https://user-images.githubusercontent.com/88805634/142255560-6692e09e-7f66-4c9b-871a-e7ee3bd1900b.png)

## sample clone successfully message copy updated
![Screen Shot 2021-11-17 at 9 43 21 AM](https://user-images.githubusercontent.com/88805634/142255563-63af00c9-083b-400c-b78f-1746681a191f.png)

## resulting folder structure
![Screen Shot 2021-11-17 at 9 44 28 AM](https://user-images.githubusercontent.com/88805634/142255564-b2ede154-d45e-4bf1-a1dd-5148da5466c3.png)


