### PR TITLE
Revert "open sample readme in default browser"

### DIFF
--- a/src/stripeSamples.ts
+++ b/src/stripeSamples.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import {ProgressLocation, QuickPickItem, Uri, commands, env, window, workspace} from 'vscode';
+import {ProgressLocation, QuickPickItem, Uri, commands, window, workspace} from 'vscode';
 import {SampleConfigsRequest, SampleConfigsResponse} from './rpc/sample_configs_pb';
 import {SampleCreateRequest, SampleCreateResponse} from './rpc/sample_create_pb';
 import {SamplesListRequest, SamplesListResponse} from './rpc/samples_list_pb';
@@ -103,7 +103,7 @@ export class StripeSamples {
               : `${sampleIsReady}.`
             : `${sampleIsReady}, but we could not set the API keys in the .env file. Please set them manually.`;
 
-          await this.promptOpenFolder(postInstallMessage, clonePath, sampleName);
+          await this.promptOpenFolder(postInstallMessage, clonePath);
         },
       );
     } catch (e: any) {
@@ -304,16 +304,11 @@ export class StripeSamples {
   /**
    * Ask if the user wants to open the sample in the same or new window
    */
-  private promptOpenFolder = async (postInstallMessage: string, clonePath: string, sampleName: string): Promise<void> => {
+  private promptOpenFolder = async (postInstallMessage: string, path: string): Promise<void> => {
     const openFolderOptions = {
       sameWindow: 'Open in same window',
       newWindow: 'Open in new window',
     };
-
-    // open the readme file in a new browser window
-    // cant open in the editor because cannot update user setting 'workbench.startupEditor​' from stripe extension
-    // preview markdown also does not work because opening new workspace will terminate the stripe extension process
-    env.openExternal(Uri.parse(`https://github.com/stripe-samples/${sampleName}#readme`));
 
     const selectedOption = await window.showInformationMessage(
       postInstallMessage,
@@ -323,12 +318,12 @@ export class StripeSamples {
 
     switch (selectedOption) {
       case openFolderOptions.sameWindow:
-        await commands.executeCommand('vscode.openFolder', Uri.file(clonePath), {
+        await commands.executeCommand('vscode.openFolder', Uri.file(path), {
           forceNewWindow: false,
         });
         break;
       case openFolderOptions.newWindow:
-        await commands.executeCommand('vscode.openFolder', Uri.file(clonePath), {
+        await commands.executeCommand('vscode.openFolder', Uri.file(path), {
           forceNewWindow: true,
         });
         break;

--- a/test/suite/stripeSamples.test.ts
+++ b/test/suite/stripeSamples.test.ts
@@ -91,8 +91,6 @@ suite('StripeSamples', function () {
         const showInformationMessageStub = sandbox
           .stub(vscode.window, 'showInformationMessage')
           .resolves();
-        const openSampleReadmeSpy = sandbox.spy(vscode.env, 'openExternal');
-
         const stripeSamples = new StripeSamples(<any>stripeClient, <any>stripeDaemon);
 
         stripeSamples.selectAndCloneSample();
@@ -103,7 +101,6 @@ suite('StripeSamples', function () {
         assert.strictEqual(showInputBoxStub.callCount, 1);
         assert.strictEqual(showOpenDialogStub.callCount, 1);
         assert.strictEqual(showInformationMessageStub.callCount, 1);
-        assert.strictEqual(openSampleReadmeSpy.callCount, 1);
       });
 
       test('shows special post install message if API keys could not be set', async () => {
@@ -130,8 +127,6 @@ suite('StripeSamples', function () {
         const showInformationMessageStub = sandbox
           .stub(vscode.window, 'showInformationMessage')
           .resolves();
-        sandbox.spy(vscode.env, 'openExternal');
-
         const stripeSamples = new StripeSamples(<any>stripeClient, <any>stripeDaemon);
 
         stripeSamples.selectAndCloneSample();


### PR DESCRIPTION
Reverts stripe/vscode-stripe#446

reverting to investigate build failures
https://github.com/stripe/vscode-stripe/runs/4256626806?check_suite_focus=true