### PR TITLE
Outputting a better error message when the MSBuild tool cannot be found

### DIFF
--- a/src/stripeDotnetLanguageServer/stripe.LanguageServer/Program.cs
+++ b/src/stripeDotnetLanguageServer/stripe.LanguageServer/Program.cs
@@ -30,7 +30,20 @@ namespace stripe.LanguageServer
             Log.Debug("Creating project for " + projectFile);
 
             // Without this MSBuild can't find the SDK folder.
-            MSBuildLocator.RegisterDefaults();
+            try
+            {
+                MSBuildLocator.RegisterDefaults();
+            } catch (Exception e)
+            {
+                // The locator cannot find the MSBuild tool in the user's sdk path
+                // or, it cannot find an sdk folder
+                Console.Error.Write("Unable to find MSBuild tools or the expected SDK version to compile your project. \n"
+                    + "Please ensure you have the dotnet Core SDK installed to get API reference features of the extension: "
+                    + "https://stripe.com/docs/stripe-vscode#api-reference\n");
+                return;
+            }
+
+
             var workspace = MSBuildWorkspace.Create();
 
             // We need to register to the failed event to be notified if there were any failures.


### PR DESCRIPTION
Note: I was able to reproduce the error by deleting the sdk folders under `/usr/local/share/dotnet/sdk` -- there may be other conditions where folks have an sdk inside the folder but the msbuild tool can still not be found.

1. Updated the error message return from the server which will directly show up on the output channel.
2. Overrode the error function to not show the notification box because without this change it'll still show the generic message as below. Another alternative was to update the `showNotificationMessage` but the closed event does not accept any messages from the server, so we would be changing the message for all notifications. 
https://github.com/microsoft/vscode-languageserver-node/blob/756cf416e98bc9ce843416cf1c03881ddd1ef322/client/src/common/client.ts#L310


Before:
<img width="945" alt="Screen Shot 2021-12-02 at 9 38 58 AM" src="https://user-images.githubusercontent.com/75757829/144671666-7507ebf1-df06-4fea-b2be-9e302d67779b.png">
After (Without hiding notification):
<img width="1372" alt="Screen Shot 2021-12-03 at 12 47 28 PM" src="https://user-images.githubusercontent.com/75757829/144671662-5719052c-06f0-4b09-a871-bc5fb9750de4.png">

