### PR TITLE
Using the isTelemetryEnabled provided by VSCode and fixing unit tests

### DIFF
--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -9,9 +9,7 @@ const osName = require('os-name');
 
 export const areAllTelemetryConfigsEnabled = () => {
   // respect both the overall and Stripe-specific telemetry configs
-  const enableTelemetry = vscode.workspace
-    .getConfiguration('telemetry')
-    .get('enableTelemetry', false);
+  const enableTelemetry = vscode.env.isTelemetryEnabled;
 
   const stripeEnableTelemetry = vscode.workspace
     .getConfiguration('stripe.telemetry')
@@ -109,6 +107,10 @@ export class StripeAnalyticsServiceTelemetry implements Telemetry {
   }
 
   private configurationChanged(e: vscode.ConfigurationChangeEvent) {
+    this._isTelemetryEnabled = areAllTelemetryConfigsEnabled();
+  }
+
+  private telemetryPreferenceChanged(e: boolean) {
     this._isTelemetryEnabled = areAllTelemetryConfigsEnabled();
   }
 }

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -109,8 +109,4 @@ export class StripeAnalyticsServiceTelemetry implements Telemetry {
   private configurationChanged(e: vscode.ConfigurationChangeEvent) {
     this._isTelemetryEnabled = areAllTelemetryConfigsEnabled();
   }
-
-  private telemetryPreferenceChanged(e: boolean) {
-    this._isTelemetryEnabled = areAllTelemetryConfigsEnabled();
-  }
 }


### PR DESCRIPTION
This API also respects the telemetry flag passed in through the CLI when the user starts their code session: https://code.visualstudio.com/updates/v1_55#_telemetry-enablement-api

Regarding the tests, the original tests were not working because it would fail at the line below with an error saying that the update function did not exist.
```
await vscode.workspace.getConfiguration('telemetry').update('stripe', undefined);
```
This was because we stubbed out the result returned by `getConfiguration` and the stubbed result did not have it. However, we don't really need to call update to simulate a config change since we are calling the constructor which calls `areAllTelemetryConfigsEnabled` anyway. 

The reason why the tests did not pass was because we would reach the end of the test case before we reached the exception above. I also updated the tests to wait for all the cases before moving forward. 