### PR TITLE
Add stripe-app.json schema link

### DIFF
--- a/package.json
+++ b/package.json
@@ -472,6 +472,10 @@
       {
         "fileMatch": "/stripe.fixture.json",
         "url": "./schemas/stripe.fixture.schema.json"
+      },
+      {
+        "fileMatch": "stripe-app.json",
+        "url": "https://raw.githubusercontent.com/stripe/stripe-apps/main/schema/stripe-app.schema.json"
       }
     ]
   },


### PR DESCRIPTION
This PR adds a `jsonValidation` entry to `package.json` that enables the Stripe App manifest schema [hosted in the Stripe Apps GitHub repo](https://github.com/stripe/stripe-apps/blob/main/schema/stripe-app.schema.json) to validate `stripe-app.json`.