### PR TITLE
Add stripe-app.*.json schema link

### DIFF
--- a/package.json
+++ b/package.json
@@ -476,6 +476,10 @@
       {
         "fileMatch": "stripe-app.json",
         "url": "https://raw.githubusercontent.com/stripe/stripe-apps/main/schema/stripe-app.schema.json"
+      },
+      {
+        "fileMatch": "stripe-app.*.json",
+        "url": "https://raw.githubusercontent.com/stripe/stripe-apps/main/schema/stripe-app-local.schema.json"
       }
     ]
   },


### PR DESCRIPTION
Add a `jsonValidation` entry to `package.json` that enables the Stripe App local manifest schema [hosted in the Stripe Apps github repo](https://github.com/stripe/stripe-apps/blob/main/schema/stripe-app-local.schema.json) to validate `stripe-app.*.json` named (e.g. `stripe-app.dev.json`) local manifest files.