### PR TITLE
fix: terminate Xvfb server after testing is complete

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Run tests (ubuntu)
         if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: xvfb-run -a npm run test
+        run: xvfb-run -a -s '-terminate' npm run test
 
       - name: Run tests (macos, windows)
         if: ${{ !(matrix.os == 'ubuntu-latest') }}


### PR DESCRIPTION
The ubuntu test suite can hang indefinitely (see https://github.com/stripe/vscode-stripe/pull/680) even though the tests pass, since the Xvfb server is still running. Passing this argument causes the server to terminate after tests are done.
