### PR TITLE
Escape strings to be passed in as arguments.

### DIFF
--- a/src/shellEscape.ts
+++ b/src/shellEscape.ts
@@ -5,7 +5,10 @@ export function shellEscape(args: Array<string>): string {
 
   if (getOSType() === OSType.windows) {
     args.forEach(function(arg) {
-      if (/[^A-Za-z0-9_\/:=-]/.test(arg)) {
+      // Check if the argument is a file path
+      const isFilePath = /^([a-zA-Z]:)?(\\[^<>:"/\\|?*]+)+\.exe$/.test(arg);
+
+      if (!isFilePath && /[^A-Za-z0-9_\/:=-]/.test(arg)) {
         arg = '"' + arg.replace(/"/g, '\\"') + '"';
         arg = arg.replace(/^(?:"")+/g, '') // unduplicate double-quote at the beginning
           .replace(/\\"""/g, '\\"'); // remove non-escaped double-quote if there are enclosed between 2 escaped

--- a/src/shellEscape.ts
+++ b/src/shellEscape.ts
@@ -1,0 +1,27 @@
+import {OSType, getOSType} from './utils';
+
+export function shellEscape(args: Array<string>): string {
+  var output: Array<string> = [];
+
+  if (getOSType() === OSType.windows) {
+    args.forEach(function(arg) {
+      if (/[^A-Za-z0-9_\/:=-]/.test(arg)) {
+        arg = '"' + arg.replace(/"/g, '\\"') + '"';
+        arg = arg.replace(/^(?:"")+/g, '') // unduplicate double-quote at the beginning
+          .replace(/\\"""/g, '\\"'); // remove non-escaped double-quote if there are enclosed between 2 escaped
+      }
+      output.push(arg);
+    });
+    return output.join(' ');
+  } else {
+    args.forEach(function(arg) {
+      if (/[^A-Za-z0-9_\/:=-]/.test(arg)) {
+        arg = "'" + arg.replace(/'/g,"'\\''") + "'";
+        arg = arg.replace(/^(?:'')+/g, '') // unduplicate single-quote at the beginning
+          .replace(/\\'''/g, "\\'"); // remove non-escaped single-quote if there are enclosed between 2 escaped
+      };
+      output.push(arg);
+    });
+    return output.join(' ');
+  };
+};

--- a/src/stripeTerminal.ts
+++ b/src/stripeTerminal.ts
@@ -34,8 +34,6 @@ export class StripeTerminal {
 
     const commandString = shellEscape([cliPath, command, ...args, ...globalCLIFlags]);
 
-
-
     try {
       const terminal = await this.createTerminal();
       terminal.sendText(commandString);

--- a/src/stripeTerminal.ts
+++ b/src/stripeTerminal.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import {StripeClient} from './stripeClient';
+import {shellEscape} from './shellEscape';
 
 type SupportedStripeCommand = 'events' | 'listen' | 'logs' | 'login' | 'trigger';
 
@@ -29,9 +30,11 @@ export class StripeTerminal {
       }
     }
 
-    const globalCLIFLags = this.getGlobalCLIFlags();
+    const globalCLIFlags = this.getGlobalCLIFlags();
 
-    const commandString = [cliPath, command, ...args, ...globalCLIFLags].join(' ');
+    const commandString = shellEscape([cliPath, command, ...args, ...globalCLIFlags]);
+
+
 
     try {
       const terminal = await this.createTerminal();

--- a/test/suite/shellEscape.test.ts
+++ b/test/suite/shellEscape.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable quotes */
 import * as assert from 'assert';
 import * as shellEscape from '../../src/shellEscape';
 import * as sinon from 'sinon';
@@ -18,13 +19,43 @@ suite('shellEscape', () => {
   suite('shellEscape', () => {
     test('non windows case: flag with spaces', () => {
       sandbox.stub(utils, 'getOSType').returns(utils.OSType.macOSarm);
-      const output = shellEscape.shellEscape(['--project-name', 'test | whoami']);
-      assert.strictEqual(output, '--project-name \'test | whoami\'');
+      const output = shellEscape.shellEscape(['--project-name', 'test | whoami']); // test | whoami
+      assert.strictEqual(output, `--project-name 'test | whoami'`); // --project-name 'test | whoami'
+    });
+    test('non windows case: flag with single quote around entire arg', () => {
+      sandbox.stub(utils, 'getOSType').returns(utils.OSType.macOSarm);
+      const output = shellEscape.shellEscape(['--project-name', `'test name'`]); // 'test name'
+      assert.strictEqual(output, `--project-name \\''test name'\\'`); // --project-name \''test name'\'
+    });
+    test('non windows case: flag with double quote', () => {
+      sandbox.stub(utils, 'getOSType').returns(utils.OSType.macOSarm);
+      const output = shellEscape.shellEscape(['--project-name', `test "name"`]); // test "name"
+      assert.strictEqual(output, `--project-name 'test "name"'`); // --project-name 'test "name"'
+    });
+    test('non windows case: flag with lots of quotes', () => {
+      sandbox.stub(utils, 'getOSType').returns(utils.OSType.macOSarm);
+      const output = shellEscape.shellEscape(['--project-name', `'test's "name"'`]); // 'test's "name"'
+      assert.strictEqual(output, `--project-name \\''test'\\''s "name"'\\'`); // --project-name \''test'\''s "name"'\'
     });
     test.only('windows case: flag with space', () => {
       sandbox.stub(utils, 'getOSType').returns(utils.OSType.windows);
-      const output = shellEscape.shellEscape(['--project-name', 'test | whoami']);
-      assert.strictEqual(output, '--project-name \"test | whoami\"');
+      const output = shellEscape.shellEscape(['--project-name', 'test | whoami']); // test | whoami
+      assert.strictEqual(output, `--project-name "test | whoami"`); // --project-name "test | whoami"
+    });
+    test.only('windows case: flag with single quote around entire arg', () => {
+      sandbox.stub(utils, 'getOSType').returns(utils.OSType.windows);
+      const output = shellEscape.shellEscape(['--project-name', `'test name'`]); // 'test name'
+      assert.strictEqual(output, `--project-name "'test name'"`); // --project-name "'test name'"
+    });
+    test.only('windows case: flag with double quote', () => {
+      sandbox.stub(utils, 'getOSType').returns(utils.OSType.windows);
+      const output = shellEscape.shellEscape(['--project-name', `test "name"`]); // test "name"
+      assert.strictEqual(output, `--project-name "test \\"name\\""`); // --project-name "test \"name\""
+    });
+    test.only('windows case: flag with lots of quotes', () => {
+      sandbox.stub(utils, 'getOSType').returns(utils.OSType.windows);
+      const output = shellEscape.shellEscape(['--project-name', `'test's "name"'`]); // 'test's "name"'
+      assert.strictEqual(output, `--project-name "'test's \\"name\\"'"`); // --project-name "'test's \"name\"'"
     });
   });
 });

--- a/test/suite/shellEscape.test.ts
+++ b/test/suite/shellEscape.test.ts
@@ -25,6 +25,6 @@ suite('shellEscape', () => {
       sandbox.stub(utils, 'getOSType').returns(utils.OSType.windows);
       const output = shellEscape.shellEscape(['--project-name', 'test | whoami']);
       assert.strictEqual(output, '--project-name \"test | whoami\"');
-    })
+    });
   });
 });

--- a/test/suite/shellEscape.test.ts
+++ b/test/suite/shellEscape.test.ts
@@ -1,0 +1,30 @@
+import * as assert from 'assert';
+import * as shellEscape from '../../src/shellEscape';
+import * as sinon from 'sinon';
+import * as utils from '../../src/utils';
+
+
+suite('shellEscape', () => {
+  let sandbox: sinon.SinonSandbox;
+
+  setup(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  teardown(() => {
+    sandbox.restore();
+  });
+
+  suite('shellEscape', () => {
+    test('non windows case: flag with spaces', () => {
+      sandbox.stub(utils, 'getOSType').returns(utils.OSType.macOSarm);
+      const output = shellEscape.shellEscape(['--project-name', 'test | whoami']);
+      assert.strictEqual(output, '--project-name \'test | whoami\'');
+    });
+    test.only('windows case: flag with space', () => {
+      sandbox.stub(utils, 'getOSType').returns(utils.OSType.windows);
+      const output = shellEscape.shellEscape(['--project-name', 'test | whoami']);
+      assert.strictEqual(output, '--project-name \"test | whoami\"');
+    })
+  });
+});


### PR DESCRIPTION
Addresses the bug where command injection can be used in the projectName value in workspace settings, by escaping strings passed in as arguments. 

https://security-insights.corp.stripe.com/pathfinder/sats/SAT-10878

The solution is based on [shell-escape](https://www.npmjs.com/package/shell-escape), but also adapted to handle Windows computers. This was tested on both Windows and Mac.

<img width="1229" alt="Screenshot 2024-10-09 at 12 36 11 PM" src="https://github.com/user-attachments/assets/d482fff1-6f3b-43e0-85ed-7068da4495cf">