### PR TITLE
Fix auth check

### DIFF
--- a/src/stripeClient.ts
+++ b/src/stripeClient.ts
@@ -141,7 +141,7 @@ export class StripeClient {
     const projectName =
       vscode.workspace.getConfiguration('stripe').get('projectName', null) || 'default';
     try {
-      const {stdout} = await execa(await this.cliPath, ['config', '--list']);
+      const {stdout} = await execa(await this.cliPath, ['config', '--list', '--project-name', 'default']);
       const data = toml.parse(stdout);
 
       const hasConfigForProject = projectName in data;


### PR DESCRIPTION
This fixes an issue where the extension always prompts for login when you have a project name set.

To check if you're authenticated, we run `stripe config --list` and parse the TOML output. The problem is when you set a project name, `stripe config --list` doesn't return valid TOML, so we don't know that you're authenticated. 

This fixes it by explicitly setting `stripe config --list --project-name default` which prints out the config file verbatim so that it's always valid TOML.