### PR TITLE
Escape characters in project name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 .DS_Store
 test/workspace/.vscode
 dist
+jdt-language-server-latest.tar.gz

--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
         },
         "stripe.projectName": {
           "type": "string",
-          "description": "the project name to read from for config (default \"default\")"
+          "description": "the project name to read from for config (default \"default\")",
+          "pattern": "^[a-zA-Z0-9_-\\s]+$"
         },
         "stripe.telemetry.enabled": {
           "type": "boolean",

--- a/src/stripeTerminal.ts
+++ b/src/stripeTerminal.ts
@@ -61,7 +61,6 @@ export class StripeTerminal {
     if (projectName !== null) {
       projectName = projectName.replace(/[\\"'`]/g, '');
     }
-    console.log({projectName});
 
     const projectNameFlag = projectName ? ['--project-name', projectName] : [];
 

--- a/src/stripeTerminal.ts
+++ b/src/stripeTerminal.ts
@@ -38,15 +38,18 @@ export class StripeTerminal {
       'stripe',
       new vscode.ShellExecution(cliPath, [
         command,
-        ...args.map((arg) => ({
-          quoting: vscode.ShellQuoting.Strong,
-          value: arg,
-        })),
-        ...globalCLIFlags.map((arg) => ({
-          quoting: vscode.ShellQuoting.Strong,
-          value: arg,
-        })),
-      ])
+        ...args,
+        ...globalCLIFlags
+      ],
+      {
+        shellQuoting: {
+          escape: {
+            escapeChar: '\\',
+            charsToEscape: '&`|"\'',
+          }
+        }
+      }
+    )
     ));
   }
 
@@ -54,7 +57,11 @@ export class StripeTerminal {
   private getGlobalCLIFlags(): Array<string> {
     const stripeConfig = vscode.workspace.getConfiguration('stripe');
 
-    const projectName = stripeConfig.get('projectName', null);
+    let projectName = stripeConfig.get<string | null>('projectName', null);
+    if (projectName !== null) {
+      projectName = projectName.replace(/[\\"'`]/g, '');
+    }
+    console.log({projectName});
 
     const projectNameFlag = projectName ? ['--project-name', projectName] : [];
 

--- a/test/suite/stripeTerminal.test.ts
+++ b/test/suite/stripeTerminal.test.ts
@@ -52,15 +52,17 @@ suite('stripeTerminal', function () {
             'stripe',
             new vscode.ShellExecution(path, [
               'listen',
-              {
-                quoting: vscode.ShellQuoting.Strong,
-                value: '--forward-to'
+              '--forward-to',
+              'localhost',
+            ],
+            {
+              shellQuoting: {
+                escape: {
+                  escapeChar: '\\',
+                  charsToEscape: '&`|"\'',
+                },
               },
-              {
-                quoting: vscode.ShellQuoting.Strong,
-                value: 'localhost'
-              }
-            ])
+            }),
           ),
         ]);
       });


### PR DESCRIPTION
This escapes more characters in the project name configuration value so that we keep the input correct and useful.