### PR TITLE
Explicitly enforce project name constraints in StripeTerminal

### DIFF
--- a/src/stripeTerminal.ts
+++ b/src/stripeTerminal.ts
@@ -59,7 +59,7 @@ export class StripeTerminal {
 
     const projectName = stripeConfig.get<string | null>('projectName', null);
 
-    if (projectName !== null) {
+    if (projectName !== null && projectName !== '') {
         // Regex to validate project name
         const projectNameRegex = /^[a-zA-Z0-9_-\s]+$/;
 

--- a/src/stripeTerminal.ts
+++ b/src/stripeTerminal.ts
@@ -57,9 +57,16 @@ export class StripeTerminal {
   private getGlobalCLIFlags(): Array<string> {
     const stripeConfig = vscode.workspace.getConfiguration('stripe');
 
-    let projectName = stripeConfig.get<string | null>('projectName', null);
+    const projectName = stripeConfig.get<string | null>('projectName', null);
+
     if (projectName !== null) {
-      projectName = projectName.replace(/[\\"'`]/g, '');
+        // Regex to validate project name
+        const projectNameRegex = /^[a-zA-Z0-9_-\s]+$/;
+
+        // Validate project name against the regex
+        if (!projectNameRegex.test(projectName)) {
+            throw new Error(`Invalid project name: '${projectName}'. Project names can only contain letters, numbers, spaces, underscores, and hyphens.`);
+        }
     }
 
     const projectNameFlag = projectName ? ['--project-name', projectName] : [];

--- a/test/suite/stripeTerminal.test.ts
+++ b/test/suite/stripeTerminal.test.ts
@@ -4,85 +4,141 @@ import * as vscode from 'vscode';
 import {StripeTerminal} from '../../src/stripeTerminal';
 
 suite('stripeTerminal', function () {
-  this.timeout(20000);
+    this.timeout(20000);
 
-  let sandbox: sinon.SinonSandbox;
+    let sandbox: sinon.SinonSandbox;
 
-  const terminalStub = <vscode.Terminal><unknown>{
-    name: 'Stubbed Terminal',
-    processId: Promise.resolve(undefined),
-    creationOptions: {},
-    exitStatus: undefined,
-    sendText: (text: string, addNewLine?: boolean) => { },
-    show: (preserveFocus?: boolean) => { },
-    hide: () => { },
-    dispose: () => { },
-  };
+    const terminalStub = <vscode.Terminal><unknown>{
+        name: 'Stubbed Terminal',
+        processId: Promise.resolve(undefined),
+        creationOptions: {},
+        exitStatus: undefined,
+        sendText: (text: string, addNewLine?: boolean) => { },
+        show: (preserveFocus?: boolean) => { },
+        hide: () => { },
+        dispose: () => { },
+    };
 
-  setup(() => {
-    sandbox = sinon.createSandbox();
-  });
-
-  teardown(() => {
-    sandbox.restore();
-  });
-
-  ['/usr/local/bin/stripe', '/custom/path/to/stripe'].forEach((path) => {
-    suite(`when the Stripe CLI is installed at ${path}`, () => {
-      test(`runs command with ${path}`, async () => {
-        const executeTaskSpy = sandbox.spy(vscode.tasks, 'executeTask');
-        sandbox.stub(terminalStub, 'sendText');
-        sandbox
-          .stub(vscode.window, 'createTerminal')
-          .returns(terminalStub);
-        const stripeClientStub = <any>{getCLIPath: () => {}, isAuthenticated: () => true};
-        sandbox
-          .stub(stripeClientStub, 'getCLIPath')
-          .returns(Promise.resolve(path));
-
-        const stripeTerminal = new StripeTerminal(stripeClientStub);
-        await stripeTerminal.execute('listen', ['--forward-to', 'localhost']);
-
-        assert.strictEqual(executeTaskSpy.callCount, 1);
-        assert.deepStrictEqual(executeTaskSpy.args[0], [
-          new vscode.Task(
-            {type: 'stripe', command: 'listen'},
-            vscode.TaskScope.Workspace,
-            'listen',
-            'stripe',
-            new vscode.ShellExecution(path, [
-              'listen',
-              '--forward-to',
-              'localhost',
-            ],
-            {
-              shellQuoting: {
-                escape: {
-                  escapeChar: '\\',
-                  charsToEscape: '&`|"\'',
-                },
-              },
-            }),
-          ),
-        ]);
-      });
+    setup(() => {
+        sandbox = sinon.createSandbox();
     });
-  });
 
-  suite('with no Stripe CLI installed', () => {
-    test('does not run command', async () => {
-      const sendTextStub = sandbox.stub(terminalStub, 'sendText');
-      const createTerminalStub = sandbox
-        .stub(vscode.window, 'createTerminal')
-        .returns(terminalStub);
-      const stripeClientStub = <any>{getCLIPath: () => {}, isAuthenticated: () => true};
-      sandbox.stub(stripeClientStub, 'getCLIPath').returns(null);
-
-      const stripeTerminal = new StripeTerminal(stripeClientStub);
-      await stripeTerminal.execute('listen', ['--forward-to', 'localhost']);
-
-      assert.strictEqual(createTerminalStub.callCount, 0);
-      assert.deepStrictEqual(sendTextStub.callCount, 0);
+    teardown(() => {
+        sandbox.restore();
     });
-  });
+
+    ['/usr/local/bin/stripe', '/custom/path/to/stripe'].forEach((path) => {
+        suite(`when the Stripe CLI is installed at ${path}`, () => {
+            test('runs command with valid project name', async () => {
+                const executeTaskSpy = sandbox.spy(vscode.tasks, 'executeTask');
+                sandbox.stub(terminalStub, 'sendText');
+                sandbox.stub(vscode.window, 'createTerminal').returns(terminalStub);
+
+                // Mock the configuration with a valid project name
+                const stripeClientStub = <any>{
+                    getCLIPath: () => { },
+                    isAuthenticated: () => true,
+                };
+
+                // Mock the getConfiguration function to return an invalid project name
+// Mock the getConfiguration function to return a configuration object with a specific project name
+sandbox.stub(vscode.workspace, 'getConfiguration').returns({
+  get: (key: string) => {
+      if (key === 'projectName') {
+          return 'Valid_Project-Name'; // or 'Invalid Project Name!' for the invalid test
+      }
+      return null;  // Return null for any other keys
+  },
+});
+
+                sandbox.stub(stripeClientStub, 'getCLIPath').returns(Promise.resolve(path));
+
+                const stripeTerminal = new StripeTerminal(stripeClientStub);
+                await stripeTerminal.execute('listen', ['--forward-to', 'localhost']);
+
+                assert.strictEqual(executeTaskSpy.callCount, 1);
+                assert.deepStrictEqual(executeTaskSpy.args[0], [
+                    new vscode.Task(
+                        {type: 'stripe', command: 'listen'},
+                        vscode.TaskScope.Workspace,
+                        'listen',
+                        'stripe',
+                        new vscode.ShellExecution(path, [
+                            'listen',
+                            '--forward-to',
+                            'localhost',
+                            '--project-name',
+                            'Valid_Project-Name'
+                        ],
+                        {
+                            shellQuoting: {
+                                escape: {
+                                    escapeChar: '\\',
+                                    charsToEscape: '&`|"\'',
+                                },
+                            },
+                        }),
+                    ),
+                ]);
+            });
+
+            test('throws error for invalid project name', async () => {
+                // Mock the configuration with an invalid project name
+                const stripeClientStub = <any>{
+                    getCLIPath: () => { },
+                    isAuthenticated: () => true,
+                };
+
+                // Mock the getConfiguration function to return an invalid project name
+                sandbox.stub(vscode.workspace, 'getConfiguration').returns({
+                  get: (key: string) => {
+                    if (key === 'projectName') {
+                      return 'Invalid Project Name!'; // Invalid project name
+                    }
+                    return null;
+                  },
+                  has: function (section: string): boolean {
+                    throw new Error('Function not implemented.');
+                  },
+                  inspect: function <T>(section: string): { key: string; defaultValue?: T; globalValue?: T; workspaceValue?: T; workspaceFolderValue?: T; defaultLanguageValue?: T; globalLanguageValue?: T; workspaceLanguageValue?: T; workspaceFolderLanguageValue?: T; languageIds?: string[] } | undefined {
+                    throw new Error('Function not implemented.');
+                  },
+                  update: function (section: string, value: any, configurationTarget?: vscode.ConfigurationTarget | boolean | null, overrideInLanguage?: boolean): Thenable<void> {
+                    throw new Error('Function not implemented.');
+                  }
+                });
+
+                sandbox.stub(vscode.window, 'createTerminal').returns(terminalStub);
+                sandbox.stub(stripeClientStub, 'getCLIPath').returns(Promise.resolve(path));
+
+                const stripeTerminal = new StripeTerminal(stripeClientStub);
+
+                // Expect an error to be thrown due to invalid project name
+                await assert.rejects(
+                    async () => {
+                        await stripeTerminal.execute('listen', ['--forward-to', 'localhost']);
+                    },
+                    {
+                        name: 'Error',
+                        message: "Invalid project name: 'Invalid Project Name!'. Project names can only contain letters, numbers, spaces, underscores, and hyphens.",
+                    }
+                );
+            });
+        });
+    });
+
+    suite('with no Stripe CLI installed', () => {
+        test('does not run command', async () => {
+            const sendTextStub = sandbox.stub(terminalStub, 'sendText');
+            const createTerminalStub = sandbox.stub(vscode.window, 'createTerminal').returns(terminalStub);
+            const stripeClientStub = <any>{getCLIPath: () => { }, isAuthenticated: () => true};
+            sandbox.stub(stripeClientStub, 'getCLIPath').returns(null);
+
+            const stripeTerminal = new StripeTerminal(stripeClientStub);
+            await stripeTerminal.execute('listen', ['--forward-to', 'localhost']);
+
+            assert.strictEqual(createTerminalStub.callCount, 0);
+            assert.deepStrictEqual(sendTextStub.callCount, 0);
+        });
+    });
 });

--- a/test/suite/stripeTerminal.test.ts
+++ b/test/suite/stripeTerminal.test.ts
@@ -4,141 +4,189 @@ import * as vscode from 'vscode';
 import {StripeTerminal} from '../../src/stripeTerminal';
 
 suite('stripeTerminal', function () {
-    this.timeout(20000);
+  this.timeout(20000);
 
-    let sandbox: sinon.SinonSandbox;
+  let sandbox: sinon.SinonSandbox;
 
-    const terminalStub = <vscode.Terminal><unknown>{
-        name: 'Stubbed Terminal',
-        processId: Promise.resolve(undefined),
-        creationOptions: {},
-        exitStatus: undefined,
-        sendText: (text: string, addNewLine?: boolean) => { },
-        show: (preserveFocus?: boolean) => { },
-        hide: () => { },
-        dispose: () => { },
-    };
+  const terminalStub = <vscode.Terminal>(<unknown>{
+    name: 'Stubbed Terminal',
+    processId: Promise.resolve(undefined),
+    creationOptions: {},
+    exitStatus: undefined,
+    sendText: (text: string, addNewLine?: boolean) => {},
+    show: (preserveFocus?: boolean) => {},
+    hide: () => {},
+    dispose: () => {},
+  });
 
-    setup(() => {
-        sandbox = sinon.createSandbox();
-    });
+  setup(() => {
+    sandbox = sinon.createSandbox();
+  });
 
-    teardown(() => {
-        sandbox.restore();
-    });
+  teardown(() => {
+    sandbox.restore();
+  });
 
-    ['/usr/local/bin/stripe', '/custom/path/to/stripe'].forEach((path) => {
-        suite(`when the Stripe CLI is installed at ${path}`, () => {
-            test('runs command with valid project name', async () => {
-                const executeTaskSpy = sandbox.spy(vscode.tasks, 'executeTask');
-                sandbox.stub(terminalStub, 'sendText');
-                sandbox.stub(vscode.window, 'createTerminal').returns(terminalStub);
+  ['/usr/local/bin/stripe', '/custom/path/to/stripe'].forEach((path) => {
+    suite(`when the Stripe CLI is installed at ${path}`, () => {
+      test('runs command with valid project name', async () => {
+        const executeTaskSpy = sandbox.spy(vscode.tasks, 'executeTask');
+        sandbox.stub(terminalStub, 'sendText');
+        sandbox.stub(vscode.window, 'createTerminal').returns(terminalStub);
 
-                // Mock the configuration with a valid project name
-                const stripeClientStub = <any>{
-                    getCLIPath: () => { },
-                    isAuthenticated: () => true,
-                };
+        // Mock the configuration with a valid project name
+        const stripeClientStub = <any>{
+          getCLIPath: () => {},
+          isAuthenticated: () => true,
+        };
 
-                // Mock the getConfiguration function to return an invalid project name
-// Mock the getConfiguration function to return a configuration object with a specific project name
-sandbox.stub(vscode.workspace, 'getConfiguration').returns({
-  get: (key: string) => {
-      if (key === 'projectName') {
-          return 'Valid_Project-Name'; // or 'Invalid Project Name!' for the invalid test
-      }
-      return null;  // Return null for any other keys
-  },
-});
-
-                sandbox.stub(stripeClientStub, 'getCLIPath').returns(Promise.resolve(path));
-
-                const stripeTerminal = new StripeTerminal(stripeClientStub);
-                await stripeTerminal.execute('listen', ['--forward-to', 'localhost']);
-
-                assert.strictEqual(executeTaskSpy.callCount, 1);
-                assert.deepStrictEqual(executeTaskSpy.args[0], [
-                    new vscode.Task(
-                        {type: 'stripe', command: 'listen'},
-                        vscode.TaskScope.Workspace,
-                        'listen',
-                        'stripe',
-                        new vscode.ShellExecution(path, [
-                            'listen',
-                            '--forward-to',
-                            'localhost',
-                            '--project-name',
-                            'Valid_Project-Name'
-                        ],
-                        {
-                            shellQuoting: {
-                                escape: {
-                                    escapeChar: '\\',
-                                    charsToEscape: '&`|"\'',
-                                },
-                            },
-                        }),
-                    ),
-                ]);
-            });
-
-            test('throws error for invalid project name', async () => {
-                // Mock the configuration with an invalid project name
-                const stripeClientStub = <any>{
-                    getCLIPath: () => { },
-                    isAuthenticated: () => true,
-                };
-
-                // Mock the getConfiguration function to return an invalid project name
-                sandbox.stub(vscode.workspace, 'getConfiguration').returns({
-                  get: (key: string) => {
-                    if (key === 'projectName') {
-                      return 'Invalid Project Name!'; // Invalid project name
-                    }
-                    return null;
-                  },
-                  has: function (section: string): boolean {
-                    throw new Error('Function not implemented.');
-                  },
-                  inspect: function <T>(section: string): { key: string; defaultValue?: T; globalValue?: T; workspaceValue?: T; workspaceFolderValue?: T; defaultLanguageValue?: T; globalLanguageValue?: T; workspaceLanguageValue?: T; workspaceFolderLanguageValue?: T; languageIds?: string[] } | undefined {
-                    throw new Error('Function not implemented.');
-                  },
-                  update: function (section: string, value: any, configurationTarget?: vscode.ConfigurationTarget | boolean | null, overrideInLanguage?: boolean): Thenable<void> {
-                    throw new Error('Function not implemented.');
-                  }
-                });
-
-                sandbox.stub(vscode.window, 'createTerminal').returns(terminalStub);
-                sandbox.stub(stripeClientStub, 'getCLIPath').returns(Promise.resolve(path));
-
-                const stripeTerminal = new StripeTerminal(stripeClientStub);
-
-                // Expect an error to be thrown due to invalid project name
-                await assert.rejects(
-                    async () => {
-                        await stripeTerminal.execute('listen', ['--forward-to', 'localhost']);
-                    },
-                    {
-                        name: 'Error',
-                        message: "Invalid project name: 'Invalid Project Name!'. Project names can only contain letters, numbers, spaces, underscores, and hyphens.",
-                    }
-                );
-            });
+        // Mock the getConfiguration function to return an invalid project name
+        sandbox.stub(vscode.workspace, 'getConfiguration').returns({
+          get: (key: string) => {
+            if (key === 'projectName') {
+              return 'Valid_Project-Name'; // Invalid project name
+            }
+            return null;
+          },
+          has: function (section: string): boolean {
+            throw new Error('Function not implemented.');
+          },
+          inspect: function <T>(
+            section: string,
+          ):
+            | {
+                key: string;
+                defaultValue?: T;
+                globalValue?: T;
+                workspaceValue?: T;
+                workspaceFolderValue?: T;
+                defaultLanguageValue?: T;
+                globalLanguageValue?: T;
+                workspaceLanguageValue?: T;
+                workspaceFolderLanguageValue?: T;
+                languageIds?: string[];
+              }
+            | undefined {
+            throw new Error('Function not implemented.');
+          },
+          update: function (
+            section: string,
+            value: any,
+            configurationTarget?: vscode.ConfigurationTarget | boolean | null,
+            overrideInLanguage?: boolean,
+          ): Thenable<void> {
+            throw new Error('Function not implemented.');
+          },
         });
-    });
 
-    suite('with no Stripe CLI installed', () => {
-        test('does not run command', async () => {
-            const sendTextStub = sandbox.stub(terminalStub, 'sendText');
-            const createTerminalStub = sandbox.stub(vscode.window, 'createTerminal').returns(terminalStub);
-            const stripeClientStub = <any>{getCLIPath: () => { }, isAuthenticated: () => true};
-            sandbox.stub(stripeClientStub, 'getCLIPath').returns(null);
+        sandbox.stub(stripeClientStub, 'getCLIPath').returns(Promise.resolve(path));
 
-            const stripeTerminal = new StripeTerminal(stripeClientStub);
+        const stripeTerminal = new StripeTerminal(stripeClientStub);
+        await stripeTerminal.execute('listen', ['--forward-to', 'localhost']);
+
+        assert.strictEqual(executeTaskSpy.callCount, 1);
+        assert.deepStrictEqual(executeTaskSpy.args[0], [
+          new vscode.Task(
+            {type: 'stripe', command: 'listen'},
+            vscode.TaskScope.Workspace,
+            'listen',
+            'stripe',
+            new vscode.ShellExecution(
+              path,
+              ['listen', '--forward-to', 'localhost', '--project-name', 'Valid_Project-Name'],
+              {
+                shellQuoting: {
+                  escape: {
+                    escapeChar: '\\',
+                    charsToEscape: '&`|"\'',
+                  },
+                },
+              },
+            ),
+          ),
+        ]);
+      });
+
+      test('throws error for invalid project name', async () => {
+        // Mock the configuration with an invalid project name
+        const stripeClientStub = <any>{
+          getCLIPath: () => {},
+          isAuthenticated: () => true,
+        };
+
+        // Mock the getConfiguration function to return an invalid project name
+        sandbox.stub(vscode.workspace, 'getConfiguration').returns({
+          get: (key: string) => {
+            if (key === 'projectName') {
+              return 'Invalid Project Name!'; // Invalid project name
+            }
+            return null;
+          },
+          has: function (section: string): boolean {
+            throw new Error('Function not implemented.');
+          },
+          inspect: function <T>(
+            section: string,
+          ):
+            | {
+                key: string;
+                defaultValue?: T;
+                globalValue?: T;
+                workspaceValue?: T;
+                workspaceFolderValue?: T;
+                defaultLanguageValue?: T;
+                globalLanguageValue?: T;
+                workspaceLanguageValue?: T;
+                workspaceFolderLanguageValue?: T;
+                languageIds?: string[];
+              }
+            | undefined {
+            throw new Error('Function not implemented.');
+          },
+          update: function (
+            section: string,
+            value: any,
+            configurationTarget?: vscode.ConfigurationTarget | boolean | null,
+            overrideInLanguage?: boolean,
+          ): Thenable<void> {
+            throw new Error('Function not implemented.');
+          },
+        });
+
+        sandbox.stub(vscode.window, 'createTerminal').returns(terminalStub);
+        sandbox.stub(stripeClientStub, 'getCLIPath').returns(Promise.resolve(path));
+
+        const stripeTerminal = new StripeTerminal(stripeClientStub);
+
+        // Expect an error to be thrown due to invalid project name
+        await assert.rejects(
+          async () => {
             await stripeTerminal.execute('listen', ['--forward-to', 'localhost']);
-
-            assert.strictEqual(createTerminalStub.callCount, 0);
-            assert.deepStrictEqual(sendTextStub.callCount, 0);
-        });
+          },
+          {
+            name: 'Error',
+            message:
+              "Invalid project name: 'Invalid Project Name!'. Project names can only contain letters, numbers, spaces, underscores, and hyphens.",
+          },
+        );
+      });
     });
+  });
+
+  suite('with no Stripe CLI installed', () => {
+    test('does not run command', async () => {
+      const sendTextStub = sandbox.stub(terminalStub, 'sendText');
+      const createTerminalStub = sandbox
+        .stub(vscode.window, 'createTerminal')
+        .returns(terminalStub);
+      const stripeClientStub = <any>{getCLIPath: () => {}, isAuthenticated: () => true};
+      sandbox.stub(stripeClientStub, 'getCLIPath').returns(null);
+
+      const stripeTerminal = new StripeTerminal(stripeClientStub);
+      await stripeTerminal.execute('listen', ['--forward-to', 'localhost']);
+
+      assert.strictEqual(createTerminalStub.callCount, 0);
+      assert.deepStrictEqual(sendTextStub.callCount, 0);
+    });
+  });
 });

--- a/test/suite/stripeTerminal.test.ts
+++ b/test/suite/stripeTerminal.test.ts
@@ -29,16 +29,16 @@ suite('stripeTerminal', function () {
 
   ['/usr/local/bin/stripe', '/custom/path/to/stripe'].forEach((path) => {
     suite(`when the Stripe CLI is installed at ${path}`, () => {
-      test('runs command with valid project name', async () => {
+      test(`runs command with ${path}`, async () => {
         const executeTaskSpy = sandbox.spy(vscode.tasks, 'executeTask');
         sandbox.stub(terminalStub, 'sendText');
-        sandbox.stub(vscode.window, 'createTerminal').returns(terminalStub);
-
-        // Mock the configuration with a valid project name
-        const stripeClientStub = <any>{
-          getCLIPath: () => { },
-          isAuthenticated: () => true,
-        };
+        sandbox
+          .stub(vscode.window, 'createTerminal')
+          .returns(terminalStub);
+        const stripeClientStub = <any>{getCLIPath: () => {}, isAuthenticated: () => true};
+        sandbox
+          .stub(stripeClientStub, 'getCLIPath')
+          .returns(Promise.resolve(path));
 
         // Mock the getConfiguration function to return a valid project name
         sandbox.stub(vscode.workspace, 'getConfiguration').returns({
@@ -59,8 +59,6 @@ suite('stripeTerminal', function () {
           }
         });
 
-        sandbox.stub(stripeClientStub, 'getCLIPath').returns(Promise.resolve(path));
-
         const stripeTerminal = new StripeTerminal(stripeClientStub);
         await stripeTerminal.execute('listen', ['--forward-to', 'localhost']);
 
@@ -76,7 +74,7 @@ suite('stripeTerminal', function () {
               '--forward-to',
               'localhost',
               '--project-name',
-              'Valid_Project-Name'
+              'Valid_Project-Name',
             ],
             {
               shellQuoting: {
@@ -89,57 +87,59 @@ suite('stripeTerminal', function () {
           ),
         ]);
       });
+    });
 
-      test('throws error for invalid project name', async () => {
-        // Mock the configuration with an invalid project name
-        const stripeClientStub = <any>{
-          getCLIPath: () => { },
-          isAuthenticated: () => true,
-        };
+    test('throws error for invalid project name', async () => {
+      // Mock the configuration with an invalid project name
+      const stripeClientStub = <any>{
+        getCLIPath: () => { },
+        isAuthenticated: () => true,
+      };
 
-        // Mock the getConfiguration function to return an invalid project name
-        sandbox.stub(vscode.workspace, 'getConfiguration').returns({
-          get: (key: string) => {
-            if (key === 'projectName') {
-              return 'Invalid Project Name!'; // Invalid project name
-            }
-            return null;
-          },
-          has: function (section: string): boolean {
-            throw new Error('Function not implemented.');
-          },
-          inspect: function <T>(section: string): { key: string; defaultValue?: T; globalValue?: T; workspaceValue?: T; workspaceFolderValue?: T; defaultLanguageValue?: T; globalLanguageValue?: T; workspaceLanguageValue?: T; workspaceFolderLanguageValue?: T; languageIds?: string[]; } | undefined {
-            throw new Error('Function not implemented.');
-          },
-          update: function (section: string, value: any, configurationTarget?: vscode.ConfigurationTarget | boolean | null, overrideInLanguage?: boolean): Thenable<void> {
-            throw new Error('Function not implemented.');
+      // Mock the getConfiguration function to return an invalid project name
+      sandbox.stub(vscode.workspace, 'getConfiguration').returns({
+        get: (key: string) => {
+          if (key === 'projectName') {
+            return 'Invalid Project Name!'; // Invalid project name
           }
-        });
-
-        sandbox.stub(vscode.window, 'createTerminal').returns(terminalStub);
-        sandbox.stub(stripeClientStub, 'getCLIPath').returns(Promise.resolve(path));
-
-        const stripeTerminal = new StripeTerminal(stripeClientStub);
-
-        // Expect an error to be thrown due to invalid project name
-        await assert.rejects(
-          async () => {
-            await stripeTerminal.execute('listen', ['--forward-to', 'localhost']);
-          },
-          {
-            name: 'Error',
-            message: "Invalid project name: 'Invalid Project Name!'. Project names can only contain letters, numbers, spaces, underscores, and hyphens.",
-          }
-        );
+          return null;
+        },
+        has: function (section: string): boolean {
+          throw new Error('Function not implemented.');
+        },
+        inspect: function <T>(section: string): { key: string; defaultValue?: T; globalValue?: T; workspaceValue?: T; workspaceFolderValue?: T; defaultLanguageValue?: T; globalLanguageValue?: T; workspaceLanguageValue?: T; workspaceFolderLanguageValue?: T; languageIds?: string[]; } | undefined {
+          throw new Error('Function not implemented.');
+        },
+        update: function (section: string, value: any, configurationTarget?: vscode.ConfigurationTarget | boolean | null, overrideInLanguage?: boolean): Thenable<void> {
+          throw new Error('Function not implemented.');
+        }
       });
+
+      sandbox.stub(vscode.window, 'createTerminal').returns(terminalStub);
+      sandbox.stub(stripeClientStub, 'getCLIPath').returns(Promise.resolve(path));
+
+      const stripeTerminal = new StripeTerminal(stripeClientStub);
+
+      // Expect an error to be thrown due to invalid project name
+      await assert.rejects(
+        async () => {
+          await stripeTerminal.execute('listen', ['--forward-to', 'localhost']);
+        },
+        {
+          name: 'Error',
+          message: "Invalid project name: 'Invalid Project Name!'. Project names can only contain letters, numbers, spaces, underscores, and hyphens.",
+        }
+      );
     });
   });
 
   suite('with no Stripe CLI installed', () => {
     test('does not run command', async () => {
       const sendTextStub = sandbox.stub(terminalStub, 'sendText');
-      const createTerminalStub = sandbox.stub(vscode.window, 'createTerminal').returns(terminalStub);
-      const stripeClientStub = <any>{getCLIPath: () => { }, isAuthenticated: () => true};
+      const createTerminalStub = sandbox
+        .stub(vscode.window, 'createTerminal')
+        .returns(terminalStub);
+      const stripeClientStub = <any>{getCLIPath: () => {}, isAuthenticated: () => true};
       sandbox.stub(stripeClientStub, 'getCLIPath').returns(null);
 
       const stripeTerminal = new StripeTerminal(stripeClientStub);

--- a/test/suite/stripeTerminal.test.ts
+++ b/test/suite/stripeTerminal.test.ts
@@ -8,16 +8,16 @@ suite('stripeTerminal', function () {
 
   let sandbox: sinon.SinonSandbox;
 
-  const terminalStub = <vscode.Terminal>(<unknown>{
+  const terminalStub = <vscode.Terminal><unknown>{
     name: 'Stubbed Terminal',
     processId: Promise.resolve(undefined),
     creationOptions: {},
     exitStatus: undefined,
-    sendText: (text: string, addNewLine?: boolean) => {},
-    show: (preserveFocus?: boolean) => {},
-    hide: () => {},
-    dispose: () => {},
-  });
+    sendText: (text: string, addNewLine?: boolean) => { },
+    show: (preserveFocus?: boolean) => { },
+    hide: () => { },
+    dispose: () => { },
+  };
 
   setup(() => {
     sandbox = sinon.createSandbox();
@@ -36,47 +36,27 @@ suite('stripeTerminal', function () {
 
         // Mock the configuration with a valid project name
         const stripeClientStub = <any>{
-          getCLIPath: () => {},
+          getCLIPath: () => { },
           isAuthenticated: () => true,
         };
 
-        // Mock the getConfiguration function to return an invalid project name
+        // Mock the getConfiguration function to return a valid project name
         sandbox.stub(vscode.workspace, 'getConfiguration').returns({
           get: (key: string) => {
             if (key === 'projectName') {
-              return 'Valid_Project-Name'; // Invalid project name
+              return 'Valid_Project-Name'; // Valid project name
             }
             return null;
           },
           has: function (section: string): boolean {
             throw new Error('Function not implemented.');
           },
-          inspect: function <T>(
-            section: string,
-          ):
-            | {
-                key: string;
-                defaultValue?: T;
-                globalValue?: T;
-                workspaceValue?: T;
-                workspaceFolderValue?: T;
-                defaultLanguageValue?: T;
-                globalLanguageValue?: T;
-                workspaceLanguageValue?: T;
-                workspaceFolderLanguageValue?: T;
-                languageIds?: string[];
-              }
-            | undefined {
+          inspect: function <T>(section: string): { key: string; defaultValue?: T; globalValue?: T; workspaceValue?: T; workspaceFolderValue?: T; defaultLanguageValue?: T; globalLanguageValue?: T; workspaceLanguageValue?: T; workspaceFolderLanguageValue?: T; languageIds?: string[]; } | undefined {
             throw new Error('Function not implemented.');
           },
-          update: function (
-            section: string,
-            value: any,
-            configurationTarget?: vscode.ConfigurationTarget | boolean | null,
-            overrideInLanguage?: boolean,
-          ): Thenable<void> {
+          update: function (section: string, value: any, configurationTarget?: vscode.ConfigurationTarget | boolean | null, overrideInLanguage?: boolean): Thenable<void> {
             throw new Error('Function not implemented.');
-          },
+          }
         });
 
         sandbox.stub(stripeClientStub, 'getCLIPath').returns(Promise.resolve(path));
@@ -91,18 +71,21 @@ suite('stripeTerminal', function () {
             vscode.TaskScope.Workspace,
             'listen',
             'stripe',
-            new vscode.ShellExecution(
-              path,
-              ['listen', '--forward-to', 'localhost', '--project-name', 'Valid_Project-Name'],
-              {
-                shellQuoting: {
-                  escape: {
-                    escapeChar: '\\',
-                    charsToEscape: '&`|"\'',
-                  },
+            new vscode.ShellExecution(path, [
+              'listen',
+              '--forward-to',
+              'localhost',
+              '--project-name',
+              'Valid_Project-Name'
+            ],
+            {
+              shellQuoting: {
+                escape: {
+                  escapeChar: '\\',
+                  charsToEscape: '&`|"\'',
                 },
               },
-            ),
+            }),
           ),
         ]);
       });
@@ -110,7 +93,7 @@ suite('stripeTerminal', function () {
       test('throws error for invalid project name', async () => {
         // Mock the configuration with an invalid project name
         const stripeClientStub = <any>{
-          getCLIPath: () => {},
+          getCLIPath: () => { },
           isAuthenticated: () => true,
         };
 
@@ -125,32 +108,12 @@ suite('stripeTerminal', function () {
           has: function (section: string): boolean {
             throw new Error('Function not implemented.');
           },
-          inspect: function <T>(
-            section: string,
-          ):
-            | {
-                key: string;
-                defaultValue?: T;
-                globalValue?: T;
-                workspaceValue?: T;
-                workspaceFolderValue?: T;
-                defaultLanguageValue?: T;
-                globalLanguageValue?: T;
-                workspaceLanguageValue?: T;
-                workspaceFolderLanguageValue?: T;
-                languageIds?: string[];
-              }
-            | undefined {
+          inspect: function <T>(section: string): { key: string; defaultValue?: T; globalValue?: T; workspaceValue?: T; workspaceFolderValue?: T; defaultLanguageValue?: T; globalLanguageValue?: T; workspaceLanguageValue?: T; workspaceFolderLanguageValue?: T; languageIds?: string[]; } | undefined {
             throw new Error('Function not implemented.');
           },
-          update: function (
-            section: string,
-            value: any,
-            configurationTarget?: vscode.ConfigurationTarget | boolean | null,
-            overrideInLanguage?: boolean,
-          ): Thenable<void> {
+          update: function (section: string, value: any, configurationTarget?: vscode.ConfigurationTarget | boolean | null, overrideInLanguage?: boolean): Thenable<void> {
             throw new Error('Function not implemented.');
-          },
+          }
         });
 
         sandbox.stub(vscode.window, 'createTerminal').returns(terminalStub);
@@ -165,9 +128,8 @@ suite('stripeTerminal', function () {
           },
           {
             name: 'Error',
-            message:
-              "Invalid project name: 'Invalid Project Name!'. Project names can only contain letters, numbers, spaces, underscores, and hyphens.",
-          },
+            message: "Invalid project name: 'Invalid Project Name!'. Project names can only contain letters, numbers, spaces, underscores, and hyphens.",
+          }
         );
       });
     });
@@ -176,10 +138,8 @@ suite('stripeTerminal', function () {
   suite('with no Stripe CLI installed', () => {
     test('does not run command', async () => {
       const sendTextStub = sandbox.stub(terminalStub, 'sendText');
-      const createTerminalStub = sandbox
-        .stub(vscode.window, 'createTerminal')
-        .returns(terminalStub);
-      const stripeClientStub = <any>{getCLIPath: () => {}, isAuthenticated: () => true};
+      const createTerminalStub = sandbox.stub(vscode.window, 'createTerminal').returns(terminalStub);
+      const stripeClientStub = <any>{getCLIPath: () => { }, isAuthenticated: () => true};
       sandbox.stub(stripeClientStub, 'getCLIPath').returns(null);
 
       const stripeTerminal = new StripeTerminal(stripeClientStub);


### PR DESCRIPTION
While projectName has a regex enforced for an installed extension, this does not apply when debugging an extension through [VS Code's launch.json](https://code.visualstudio.com/docs/editor/debugging) capabilities.

This change adds the same regex check to that code path preventing project name use that does not conform with our package.json regex.