### PR TITLE
fix: add security prompt

### DIFF
--- a/src/securityPrompt.ts
+++ b/src/securityPrompt.ts
@@ -1,0 +1,40 @@
+import * as vscode from 'vscode';
+
+enum StorageKeys {
+  doNotShowSecurityPromptAgain = 'stripeDoNotShowSecurityPromptAgain',
+}
+
+export class SecurityPrompt {
+  storage: vscode.Memento;
+
+  constructor(context: vscode.ExtensionContext) {
+    this.storage = context.globalState;
+  }
+
+  public activate(): void {
+    if (this.shouldShowBannerOnStartup()) {
+      this.show();
+    }
+  }
+
+  public shouldShowBannerOnStartup(): boolean {
+    if (vscode.workspace.getConfiguration('stripe').has('projectName')) {
+      return true;
+    }
+    return false;
+  }
+
+  public async show() {
+    if (this.storage.get(StorageKeys.doNotShowSecurityPromptAgain)) {
+      return;
+    }
+    const selection = await vscode.window.showInformationMessage(
+      "Warning: Debugging from `launch.json` files you didn't create or using code from unofficial sources can expose your system to security risks. Please ensure you understand the implications of the code you are executing.",
+      'Do not show again',
+    );
+    if (!selection) {
+      return;
+    }
+    this.storage.update(StorageKeys.doNotShowSecurityPromptAgain, true);
+  }
+}


### PR DESCRIPTION
This prompt only shows on startup of the extension if you have a `projectName` set, and only shows upon calling a debug command if they set flag overrides. If the user selects the 'do not show again' option, it will never show regardless of project/debug settings:

https://github.com/user-attachments/assets/be0b5857-4602-4e3f-9ff4-e48022a352ad

